### PR TITLE
Removed $id$ tags

### DIFF
--- a/_sqlmap.py
+++ b/_sqlmap.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/extra/__init__.py
+++ b/extra/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/extra/cloak/__init__.py
+++ b/extra/cloak/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/extra/cloak/cloak.py
+++ b/extra/cloak/cloak.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 cloak.py - Simple file encryption/compression utility
 
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)

--- a/extra/dbgtool/__init__.py
+++ b/extra/dbgtool/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/extra/dbgtool/dbgtool.py
+++ b/extra/dbgtool/dbgtool.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 dbgtool.py - Portable executable to ASCII debug script converter
 
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)

--- a/extra/magic/magic.py
+++ b/extra/magic/magic.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Adam Hupp <adam@hupp.org>
 
 Reference: http://hupp.org/adam/hg/python-magic

--- a/extra/mssqlsig/update.py
+++ b/extra/mssqlsig/update.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/extra/multipart/multipartpost.py
+++ b/extra/multipart/multipartpost.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 02/2006 Will Holcomb <wholcomb@gmail.com>
 
 Reference: http://odin.himinbi.org/MultipartPostHandler.py

--- a/extra/safe2bin/__init__.py
+++ b/extra/safe2bin/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/extra/safe2bin/safe2bin.py
+++ b/extra/safe2bin/safe2bin.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 safe2bin.py - Simple safe(hex) to binary format converter
 
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)

--- a/extra/shutils/blanks.sh
+++ b/extra/shutils/blanks.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-# $Id$
-
-# Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
+# # Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 # See the file 'doc/COPYING' for copying permission
 
 # Removes trailing spaces from blank lines inside project files

--- a/extra/shutils/duplicates.py
+++ b/extra/shutils/duplicates.py
@@ -2,8 +2,6 @@
 
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 

--- a/extra/shutils/id.sh
+++ b/extra/shutils/id.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-# $Id$
-
-# Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
+# # Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 # See the file 'doc/COPYING' for copying permission
 
 # Adds SVN property 'Id' to project files

--- a/extra/socks/__init__.py
+++ b/extra/socks/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/extra/sqlharvest/__init__.py
+++ b/extra/sqlharvest/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/extra/sqlharvest/sqlharvest.py
+++ b/extra/sqlharvest/sqlharvest.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/controller/__init__.py
+++ b/lib/controller/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/controller/action.py
+++ b/lib/controller/action.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/controller/checks.py
+++ b/lib/controller/checks.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/controller/handler.py
+++ b/lib/controller/handler.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/__init__.py
+++ b/lib/core/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/agent.py
+++ b/lib/core/agent.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/bigarray.py
+++ b/lib/core/bigarray.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/convert.py
+++ b/lib/core/convert.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/data.py
+++ b/lib/core/data.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/datatype.py
+++ b/lib/core/datatype.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/defaults.py
+++ b/lib/core/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/dicts.py
+++ b/lib/core/dicts.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/dump.py
+++ b/lib/core/dump.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/enums.py
+++ b/lib/core/enums.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/exception.py
+++ b/lib/core/exception.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/optiondict.py
+++ b/lib/core/optiondict.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/profiling.py
+++ b/lib/core/profiling.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/progress.py
+++ b/lib/core/progress.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/purge.py
+++ b/lib/core/purge.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/readlineng.py
+++ b/lib/core/readlineng.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/replication.py
+++ b/lib/core/replication.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/revision.py
+++ b/lib/core/revision.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/session.py
+++ b/lib/core/session.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/shell.py
+++ b/lib/core/shell.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/subprocessng.py
+++ b/lib/core/subprocessng.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/testing.py
+++ b/lib/core/testing.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/threads.py
+++ b/lib/core/threads.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/unescaper.py
+++ b/lib/core/unescaper.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/update.py
+++ b/lib/core/update.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/core/wordlist.py
+++ b/lib/core/wordlist.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/parse/__init__.py
+++ b/lib/parse/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/parse/banner.py
+++ b/lib/parse/banner.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/parse/configfile.py
+++ b/lib/parse/configfile.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/parse/handler.py
+++ b/lib/parse/handler.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/parse/headers.py
+++ b/lib/parse/headers.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/parse/html.py
+++ b/lib/parse/html.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/parse/payloads.py
+++ b/lib/parse/payloads.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/__init__.py
+++ b/lib/request/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/basic.py
+++ b/lib/request/basic.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/basicauthhandler.py
+++ b/lib/request/basicauthhandler.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/certhandler.py
+++ b/lib/request/certhandler.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/comparison.py
+++ b/lib/request/comparison.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/direct.py
+++ b/lib/request/direct.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/dns.py
+++ b/lib/request/dns.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/httpshandler.py
+++ b/lib/request/httpshandler.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/inject.py
+++ b/lib/request/inject.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/methodrequest.py
+++ b/lib/request/methodrequest.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/proxy.py
+++ b/lib/request/proxy.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/rangehandler.py
+++ b/lib/request/rangehandler.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/redirecthandler.py
+++ b/lib/request/redirecthandler.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/request/templates.py
+++ b/lib/request/templates.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/takeover/__init__.py
+++ b/lib/takeover/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/takeover/abstraction.py
+++ b/lib/takeover/abstraction.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/takeover/icmpsh.py
+++ b/lib/takeover/icmpsh.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/takeover/metasploit.py
+++ b/lib/takeover/metasploit.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/takeover/registry.py
+++ b/lib/takeover/registry.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/takeover/udf.py
+++ b/lib/takeover/udf.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/takeover/web.py
+++ b/lib/takeover/web.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/takeover/xp_cmdshell.py
+++ b/lib/takeover/xp_cmdshell.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/__init__.py
+++ b/lib/techniques/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/blind/__init__.py
+++ b/lib/techniques/blind/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/blind/inference.py
+++ b/lib/techniques/blind/inference.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/brute/__init__.py
+++ b/lib/techniques/brute/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/brute/use.py
+++ b/lib/techniques/brute/use.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/dns/__init__.py
+++ b/lib/techniques/dns/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/dns/test.py
+++ b/lib/techniques/dns/test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/dns/use.py
+++ b/lib/techniques/dns/use.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/error/__init__.py
+++ b/lib/techniques/error/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/error/use.py
+++ b/lib/techniques/error/use.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/union/__init__.py
+++ b/lib/techniques/union/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/union/test.py
+++ b/lib/techniques/union/test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/techniques/union/use.py
+++ b/lib/techniques/union/use.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/checkpayload.py
+++ b/lib/utils/checkpayload.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/crawler.py
+++ b/lib/utils/crawler.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/deps.py
+++ b/lib/utils/deps.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/getch.py
+++ b/lib/utils/getch.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/google.py
+++ b/lib/utils/google.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/hash.py
+++ b/lib/utils/hash.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/hashdb.py
+++ b/lib/utils/hashdb.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/lib/utils/timeout.py
+++ b/lib/utils/timeout.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/__init__.py
+++ b/plugins/dbms/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/access/__init__.py
+++ b/plugins/dbms/access/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/access/connector.py
+++ b/plugins/dbms/access/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/access/enumeration.py
+++ b/plugins/dbms/access/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/access/filesystem.py
+++ b/plugins/dbms/access/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/access/fingerprint.py
+++ b/plugins/dbms/access/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/access/syntax.py
+++ b/plugins/dbms/access/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/access/takeover.py
+++ b/plugins/dbms/access/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/db2/connector.py
+++ b/plugins/dbms/db2/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/db2/filesystem.py
+++ b/plugins/dbms/db2/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/db2/fingerprint.py
+++ b/plugins/dbms/db2/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/db2/takeover.py
+++ b/plugins/dbms/db2/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/firebird/__init__.py
+++ b/plugins/dbms/firebird/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/firebird/connector.py
+++ b/plugins/dbms/firebird/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/firebird/enumeration.py
+++ b/plugins/dbms/firebird/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/firebird/filesystem.py
+++ b/plugins/dbms/firebird/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/firebird/fingerprint.py
+++ b/plugins/dbms/firebird/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/firebird/syntax.py
+++ b/plugins/dbms/firebird/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/firebird/takeover.py
+++ b/plugins/dbms/firebird/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/maxdb/__init__.py
+++ b/plugins/dbms/maxdb/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/maxdb/connector.py
+++ b/plugins/dbms/maxdb/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/maxdb/enumeration.py
+++ b/plugins/dbms/maxdb/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/maxdb/filesystem.py
+++ b/plugins/dbms/maxdb/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/maxdb/fingerprint.py
+++ b/plugins/dbms/maxdb/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/maxdb/syntax.py
+++ b/plugins/dbms/maxdb/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/maxdb/takeover.py
+++ b/plugins/dbms/maxdb/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mssqlserver/__init__.py
+++ b/plugins/dbms/mssqlserver/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mssqlserver/connector.py
+++ b/plugins/dbms/mssqlserver/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mssqlserver/enumeration.py
+++ b/plugins/dbms/mssqlserver/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mssqlserver/filesystem.py
+++ b/plugins/dbms/mssqlserver/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mssqlserver/fingerprint.py
+++ b/plugins/dbms/mssqlserver/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mssqlserver/syntax.py
+++ b/plugins/dbms/mssqlserver/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mssqlserver/takeover.py
+++ b/plugins/dbms/mssqlserver/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mysql/__init__.py
+++ b/plugins/dbms/mysql/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mysql/connector.py
+++ b/plugins/dbms/mysql/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mysql/enumeration.py
+++ b/plugins/dbms/mysql/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mysql/filesystem.py
+++ b/plugins/dbms/mysql/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mysql/fingerprint.py
+++ b/plugins/dbms/mysql/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mysql/syntax.py
+++ b/plugins/dbms/mysql/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/mysql/takeover.py
+++ b/plugins/dbms/mysql/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/oracle/__init__.py
+++ b/plugins/dbms/oracle/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/oracle/connector.py
+++ b/plugins/dbms/oracle/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/oracle/enumeration.py
+++ b/plugins/dbms/oracle/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/oracle/filesystem.py
+++ b/plugins/dbms/oracle/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/oracle/fingerprint.py
+++ b/plugins/dbms/oracle/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/oracle/syntax.py
+++ b/plugins/dbms/oracle/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/oracle/takeover.py
+++ b/plugins/dbms/oracle/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/postgresql/__init__.py
+++ b/plugins/dbms/postgresql/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/postgresql/connector.py
+++ b/plugins/dbms/postgresql/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/postgresql/enumeration.py
+++ b/plugins/dbms/postgresql/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/postgresql/filesystem.py
+++ b/plugins/dbms/postgresql/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/postgresql/fingerprint.py
+++ b/plugins/dbms/postgresql/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/postgresql/syntax.py
+++ b/plugins/dbms/postgresql/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/postgresql/takeover.py
+++ b/plugins/dbms/postgresql/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sqlite/__init__.py
+++ b/plugins/dbms/sqlite/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sqlite/connector.py
+++ b/plugins/dbms/sqlite/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sqlite/enumeration.py
+++ b/plugins/dbms/sqlite/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sqlite/filesystem.py
+++ b/plugins/dbms/sqlite/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sqlite/fingerprint.py
+++ b/plugins/dbms/sqlite/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sqlite/syntax.py
+++ b/plugins/dbms/sqlite/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sqlite/takeover.py
+++ b/plugins/dbms/sqlite/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sybase/__init__.py
+++ b/plugins/dbms/sybase/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sybase/connector.py
+++ b/plugins/dbms/sybase/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sybase/enumeration.py
+++ b/plugins/dbms/sybase/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sybase/filesystem.py
+++ b/plugins/dbms/sybase/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sybase/fingerprint.py
+++ b/plugins/dbms/sybase/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sybase/syntax.py
+++ b/plugins/dbms/sybase/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/dbms/sybase/takeover.py
+++ b/plugins/dbms/sybase/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/generic/__init__.py
+++ b/plugins/generic/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/generic/connector.py
+++ b/plugins/generic/connector.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/generic/enumeration.py
+++ b/plugins/generic/enumeration.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/generic/filesystem.py
+++ b/plugins/generic/filesystem.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/generic/fingerprint.py
+++ b/plugins/generic/fingerprint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/generic/misc.py
+++ b/plugins/generic/misc.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/generic/syntax.py
+++ b/plugins/generic/syntax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/plugins/generic/takeover.py
+++ b/plugins/generic/takeover.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/sqlmap.py
+++ b/sqlmap.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/__init__.py
+++ b/tamper/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/apostrophemask.py
+++ b/tamper/apostrophemask.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/apostrophenullencode.py
+++ b/tamper/apostrophenullencode.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/appendnullbyte.py
+++ b/tamper/appendnullbyte.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/base64encode.py
+++ b/tamper/base64encode.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/between.py
+++ b/tamper/between.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/chardoubleencode.py
+++ b/tamper/chardoubleencode.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/charencode.py
+++ b/tamper/charencode.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/charunicodeencode.py
+++ b/tamper/charunicodeencode.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/equaltolike.py
+++ b/tamper/equaltolike.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/ifnull2ifisnull.py
+++ b/tamper/ifnull2ifisnull.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/modsecurityversioned.py
+++ b/tamper/modsecurityversioned.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/modsecurityzeroversioned.py
+++ b/tamper/modsecurityzeroversioned.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/multiplespaces.py
+++ b/tamper/multiplespaces.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/percentage.py
+++ b/tamper/percentage.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/randomcase.py
+++ b/tamper/randomcase.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/randomcomments.py
+++ b/tamper/randomcomments.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/securesphere.py
+++ b/tamper/securesphere.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2comment.py
+++ b/tamper/space2comment.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2dash.py
+++ b/tamper/space2dash.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2hash.py
+++ b/tamper/space2hash.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2morehash.py
+++ b/tamper/space2morehash.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2mssqlblank.py
+++ b/tamper/space2mssqlblank.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2mssqlhash.py
+++ b/tamper/space2mssqlhash.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2mysqlblank.py
+++ b/tamper/space2mysqlblank.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2mysqldash.py
+++ b/tamper/space2mysqldash.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2plus.py
+++ b/tamper/space2plus.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/space2randomblank.py
+++ b/tamper/space2randomblank.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/unionalltounion.py
+++ b/tamper/unionalltounion.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/unmagicquotes.py
+++ b/tamper/unmagicquotes.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/versionedkeywords.py
+++ b/tamper/versionedkeywords.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """

--- a/tamper/versionedmorekeywords.py
+++ b/tamper/versionedmorekeywords.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 """
-$Id$
-
 Copyright (c) 2006-2012 sqlmap developers (http://www.sqlmap.org/)
 See the file 'doc/COPYING' for copying permission
 """


### PR DESCRIPTION
Git by default is not designed to use them, and can cause a lot of pain in a distributed VCS.
They are discouraged: see http://www.gelato.unsw.edu.au/archives/git/0610/28891.html
