### PR TITLE
Missing DUMP_NEWLINE_MARKER

### DIFF
--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -126,6 +126,11 @@ from lib.core.settings import UNION_UNIQUE_FIFO_LENGTH
 from lib.core.settings import URI_QUESTION_MARKER
 from lib.core.threads import getCurrentThreadData
 
+from lib.core.settings import DUMP_NEWLINE_MARKER
+from lib.core.settings import DUMP_CR_MARKER
+from lib.core.settings import DUMP_TAB_MARKER
+from lib.core.settings import DUMP_DEL_MARKER
+
 class UnicodeRawConfigParser(RawConfigParser):
     """
     RawConfigParser with unicode writing support

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -485,3 +485,10 @@ GENERIC_SQL_COMMENT = "-- "
 
 # Threshold value for turning back on time auto-adjustment mechanism
 VALID_TIME_CHARS_RUN_THRESHOLD = 100
+
+# dump markers
+DUMP_NEWLINE_MARKER = "__NEWLINE__"
+DUMP_CR_MARKER = "__CARRIAGE_RETURN__"
+DUMP_TAB_MARKER = "__TAB__"
+DUMP_DEL_MARKER = "__DEL__"
+


### PR DESCRIPTION
I got an error saying that the DUMP_NEWINE_MARKER was missing
  NameError: global name 'DUMP_NEWLINE_MARKER' is not defined

I googled the variable and got this

https://svn.sqlmap.org/sqlmap/trunk/sqlmap/lib/core/common.py
https://svn.sqlmap.org/sqlmap/trunk/sqlmap/lib/core/settings.py

Slapped in the code and it worked!
