### PR TITLE
 Added --output-dir option to allow specifying directory for storing files

### DIFF
--- a/_sqlmap.py
+++ b/_sqlmap.py
@@ -58,14 +58,15 @@ def main():
 
     try:
         paths.SQLMAP_ROOT_PATH = modulePath()
-        setPaths()
+        options = cmdLineParser()
+        setPaths(options)
         banner()
 
         dataToStdout("[!] legal disclaimer: %s\n\n" % LEGAL_DISCLAIMER, forceOutput=True)
         dataToStdout("[*] starting at %s\n\n" % time.strftime("%X"), forceOutput=True)
 
         # Store original command line options for possible later restoration
-        cmdLineOptions.update(cmdLineParser().__dict__)
+        cmdLineOptions.update(options.__dict__)
 
         init(cmdLineOptions)
 

--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -872,7 +872,7 @@ def cleanQuery(query):
 
     return retVal
 
-def setPaths():
+def setPaths(options):
     """
     Sets absolute paths for project directories and files
     """
@@ -886,7 +886,10 @@ def setPaths():
     paths.SQLMAP_UDF_PATH = os.path.join(paths.SQLMAP_ROOT_PATH, "udf")
     paths.SQLMAP_XML_PATH = os.path.join(paths.SQLMAP_ROOT_PATH, "xml")
     paths.SQLMAP_XML_BANNER_PATH = os.path.join(paths.SQLMAP_XML_PATH, "banner")
-    paths.SQLMAP_OUTPUT_PATH = os.path.join(paths.SQLMAP_ROOT_PATH, "output")
+    if options.output_dir:
+        paths.SQLMAP_OUTPUT_PATH = options.output_dir
+    else:
+        paths.SQLMAP_OUTPUT_PATH = os.path.join(paths.SQLMAP_ROOT_PATH, "output")
     paths.SQLMAP_DUMP_PATH = os.path.join(paths.SQLMAP_OUTPUT_PATH, "%s", "dump")
     paths.SQLMAP_FILES_PATH = os.path.join(paths.SQLMAP_OUTPUT_PATH, "%s", "files")
     paths.SQLMAP_SEXEC_PATH = os.path.join(paths.SQLMAP_EXTRAS_PATH, "shellcodeexec")

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -566,6 +566,10 @@ def cmdLineParser():
                             action="store_true",
                             help="Update sqlmap")
 
+        general.add_option("--output-dir", dest="output_dir",
+                            action="store",
+                            help="Directory to store output files in.")
+
         # Miscellaneous options
         miscellaneous = OptionGroup(parser, "Miscellaneous")
 


### PR DESCRIPTION
- _sqlmap.py 
  - move command line parsing to earlier in main to allow setPaths to know output_dir.
  - Change cmdLineOptions update to reflect earlier parsing
- lib/core/common.py
  - setPaths is now passed the command line options so they can be used for setting the path.
- lib/core/cmdline.py 
  - added OptionParser option for the new option.
