### PR TITLE
added support for dotted database-, table- and column-names for mysql

### DIFF
--- a/plugins/generic/enumeration.py
+++ b/plugins/generic/enumeration.py
@@ -1625,7 +1625,10 @@ class Enumeration:
                                 entries = zip(*[entries[colName] for colName in colList])
                         else:
                             query = rootQuery.inband.query % (colString, conf.db, tbl)
-                    elif Backend.getIdentifiedDbms() in (DBMS.MYSQL, DBMS.PGSQL):
+                    elif Backend.getIdentifiedDbms() in (DBMS.PGSQL):
+                        query = rootQuery.inband.query % (colString, conf.db, tbl, prioritySortColumns(colList)[0])
+                    elif Backend.getIdentifiedDbms() in (DBMS.MYSQL):
+                        colString = '`%s`' % colString
                         query = rootQuery.inband.query % (colString, conf.db, tbl, prioritySortColumns(colList)[0])
                     else:
                         query = rootQuery.inband.query % (colString, conf.db, tbl)

--- a/xml/queries.xml
+++ b/xml/queries.xml
@@ -12,7 +12,7 @@
         <limitgroupstart query="1"/>
         <limitgroupstop query="2"/>
         <limitstring query=" LIMIT "/>
-        <order query="ORDER BY %s ASC"/>
+        <order query="ORDER BY `%s` ASC"/>
         <count query="COUNT(%s)"/>
         <comment query="-- " query2="/*" query3="#"/>
         <!--
@@ -58,8 +58,8 @@
             <blind query="SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='%s' AND table_schema='%s'" query2="SELECT column_type FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='%s' AND column_name='%s' AND table_schema='%s'" count="SELECT COUNT(column_name) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='%s' AND table_schema='%s'" condition="column_name"/>
         </columns>
         <dump_table>
-            <inband query="SELECT %s FROM %s.%s ORDER BY %s"/>
-            <blind query="SELECT %s FROM %s.%s ORDER BY %s LIMIT %d,1" count="SELECT COUNT(*) FROM %s.%s"/>
+            <inband query="SELECT %s FROM `%s`.`%s` ORDER BY `%s`"/>
+            <blind query="SELECT %s FROM `%s`.`%s` ORDER BY `%s` LIMIT %d,1" count="SELECT COUNT(*) FROM `%s`.`%s`"/>
         </dump_table>
         <search_db>
             <inband query="SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA WHERE " query2="SELECT db FROM mysql.db WHERE " condition="schema_name" condition2="db"/>


### PR DESCRIPTION
There was an error when the database/table or columns has a '.' in the name.
This is only for mysql, I will look at other databases later.
