### PR TITLE
 fixed typo, wrong datatype for the option 'notString'

### DIFF
--- a/lib/core/optiondict.py
+++ b/lib/core/optiondict.py
@@ -76,7 +76,7 @@ optDict = {
                                "level":             "integer",
                                "risk":              "integer",
                                "string":            "string",
-                               "notString":         "notString",
+                               "notString":         "string",
                                "regexp":            "string",
                                "code":              "integer",
                                "textOnly":          "boolean",


### PR DESCRIPTION
Fixed typo that created an invalid configuration file with the option '--save'.
Wrong datatype for the option 'notString'
