### PR TITLE
Fix - Custom objects cannot be serialized in JSON

### DIFF
--- a/lib/utils/api.py
+++ b/lib/utils/api.py
@@ -340,7 +340,8 @@ def task_list(taskid):
     """
     if is_admin(taskid):
         logger.debug("Listed task pull")
-        return jsonize({"tasks": tasks, "tasks_num": len(tasks)})
+        task_list = list(tasks)
+        return jsonize({"tasks": task_list, "tasks_num": len(tasks)})
     else:
         abort(401)
 


### PR DESCRIPTION
Custom objects cannot be serialized in JSON, convert tasks into list before serializing.
