### PR TITLE
Remove appending of --+

### DIFF
--- a/tamper/unmagicquotes.py
+++ b/tamper/unmagicquotes.py
@@ -20,7 +20,8 @@ def tamper(payload, **kwargs):
     generic comment at the end (to make it work)
 
     Notes:
-        * Useful for bypassing magic_quotes/addslashes feature
+        * Useful for bypassing mysql_real_escape_string/magic_quotes/addslashes feature
+        * Particularly for servers using GBK encoding
 
     Reference:
         * http://shiflett.org/blog/2006/jan/addslashes-versus-mysql-real-escape-string
@@ -42,9 +43,5 @@ def tamper(payload, **kwargs):
             else:
                 retVal += payload[i]
                 continue
-
-        if found:
-            retVal = re.sub("\s*(AND|OR)[\s(]+'[^']+'\s*(=|LIKE)\s*'.*", "", retVal)
-            retVal += "-- "
 
     return retVal


### PR DESCRIPTION
For some reason this tamper script automatically adds --+ in some cases. Unless I'm mistaken, normally this is something that should be handled by the different payloads (payloads.xml). I have found cases where using this script failed because it would add --+ even though the payload was trying to use #, and the application in question was blacklisting on --. Removing these lines allowed the script to work and payloads using either -- or # should work as normal.

Is there some particular reason for wanting to auto-add --+ within this tamper script?
