### PR TITLE
Random means no User-Agent

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -1338,6 +1338,8 @@ def _setHTTPUserAgent():
         infoMsg = "fetched random HTTP User-Agent header from "
         infoMsg += "file '%s': %s" % (paths.USER_AGENTS, userAgent)
         logger.info(infoMsg)
+        
+        conf.httpHeaders.append((HTTP_HEADER.USER_AGENT, userAgent))
 
 def _setHTTPReferer():
     """


### PR DESCRIPTION
Specifying `--random-agent` results in no User-Agent field being sent, at all, even though it prints in the status text that it picked this or that one.
