### PR TITLE
fix comments error

### DIFF
--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -472,7 +472,7 @@ def cmdLineParser():
         enumeration.add_option("--sql-file", dest="sqlFile",
                                help="Execute SQL statements from given file(s)")
 
-        # User-defined function options
+        # Brute force options
         brute = OptionGroup(parser, "Brute force", "These "
                           "options can be used to run brute force "
                           "checks")


### PR DESCRIPTION
 lib/parse/cmdline.py 

line:475 "Brute force" optiongroup comment error 

line:486 # User-defined function options
