### PR TITLE
Using Python 2 shebang

### DIFF
--- a/extra/__init__.py
+++ b/extra/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/__init__.py
+++ b/extra/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/beep/__init__.py
+++ b/extra/beep/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/beep/__init__.py
+++ b/extra/beep/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/beep/beep.py
+++ b/extra/beep/beep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 beep.py - Make a beep sound

--- a/extra/beep/beep.py
+++ b/extra/beep/beep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 beep.py - Make a beep sound

--- a/extra/cloak/__init__.py
+++ b/extra/cloak/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/cloak/__init__.py
+++ b/extra/cloak/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/cloak/cloak.py
+++ b/extra/cloak/cloak.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 cloak.py - Simple file encryption/compression utility

--- a/extra/cloak/cloak.py
+++ b/extra/cloak/cloak.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 cloak.py - Simple file encryption/compression utility

--- a/extra/dbgtool/__init__.py
+++ b/extra/dbgtool/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/dbgtool/__init__.py
+++ b/extra/dbgtool/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/dbgtool/dbgtool.py
+++ b/extra/dbgtool/dbgtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 dbgtool.py - Portable executable to ASCII debug script converter

--- a/extra/dbgtool/dbgtool.py
+++ b/extra/dbgtool/dbgtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 dbgtool.py - Portable executable to ASCII debug script converter

--- a/extra/icmpsh/__init__.py
+++ b/extra/icmpsh/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 #  icmpsh - simple icmp command shell (port of icmpsh-m.pl written in
 #  Perl by Nico Leidecker <nico@leidecker.info>)

--- a/extra/icmpsh/__init__.py
+++ b/extra/icmpsh/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 #  icmpsh - simple icmp command shell (port of icmpsh-m.pl written in
 #  Perl by Nico Leidecker <nico@leidecker.info>)

--- a/extra/icmpsh/icmpsh_m.py
+++ b/extra/icmpsh/icmpsh_m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 #  icmpsh - simple icmp command shell (port of icmpsh-m.pl written in
 #  Perl by Nico Leidecker <nico@leidecker.info>)

--- a/extra/icmpsh/icmpsh_m.py
+++ b/extra/icmpsh/icmpsh_m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 #  icmpsh - simple icmp command shell (port of icmpsh-m.pl written in
 #  Perl by Nico Leidecker <nico@leidecker.info>)

--- a/extra/mssqlsig/update.py
+++ b/extra/mssqlsig/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/mssqlsig/update.py
+++ b/extra/mssqlsig/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/safe2bin/__init__.py
+++ b/extra/safe2bin/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/safe2bin/__init__.py
+++ b/extra/safe2bin/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/safe2bin/safe2bin.py
+++ b/extra/safe2bin/safe2bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 safe2bin.py - Simple safe(hex) to binary format converter

--- a/extra/safe2bin/safe2bin.py
+++ b/extra/safe2bin/safe2bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 safe2bin.py - Simple safe(hex) to binary format converter

--- a/extra/shutils/duplicates.py
+++ b/extra/shutils/duplicates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 # Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)
 # See the file 'doc/COPYING' for copying permission

--- a/extra/shutils/duplicates.py
+++ b/extra/shutils/duplicates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 # Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)
 # See the file 'doc/COPYING' for copying permission

--- a/extra/shutils/regressiontest.py
+++ b/extra/shutils/regressiontest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 # Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)
 # See the file 'doc/COPYING' for copying permission

--- a/extra/shutils/regressiontest.py
+++ b/extra/shutils/regressiontest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 # Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)
 # See the file 'doc/COPYING' for copying permission

--- a/extra/sqlharvest/__init__.py
+++ b/extra/sqlharvest/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/sqlharvest/__init__.py
+++ b/extra/sqlharvest/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/sqlharvest/sqlharvest.py
+++ b/extra/sqlharvest/sqlharvest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/extra/sqlharvest/sqlharvest.py
+++ b/extra/sqlharvest/sqlharvest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/__init__.py
+++ b/lib/controller/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/__init__.py
+++ b/lib/controller/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/action.py
+++ b/lib/controller/action.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/action.py
+++ b/lib/controller/action.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/checks.py
+++ b/lib/controller/checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/checks.py
+++ b/lib/controller/checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/handler.py
+++ b/lib/controller/handler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/controller/handler.py
+++ b/lib/controller/handler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/__init__.py
+++ b/lib/core/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/__init__.py
+++ b/lib/core/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/agent.py
+++ b/lib/core/agent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/agent.py
+++ b/lib/core/agent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/bigarray.py
+++ b/lib/core/bigarray.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/bigarray.py
+++ b/lib/core/bigarray.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/convert.py
+++ b/lib/core/convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/convert.py
+++ b/lib/core/convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/data.py
+++ b/lib/core/data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/data.py
+++ b/lib/core/data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/datatype.py
+++ b/lib/core/datatype.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/datatype.py
+++ b/lib/core/datatype.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/decorators.py
+++ b/lib/core/decorators.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/decorators.py
+++ b/lib/core/decorators.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/defaults.py
+++ b/lib/core/defaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/defaults.py
+++ b/lib/core/defaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/dicts.py
+++ b/lib/core/dicts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/dicts.py
+++ b/lib/core/dicts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/dump.py
+++ b/lib/core/dump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/dump.py
+++ b/lib/core/dump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/enums.py
+++ b/lib/core/enums.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/enums.py
+++ b/lib/core/enums.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/exception.py
+++ b/lib/core/exception.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/exception.py
+++ b/lib/core/exception.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/log.py
+++ b/lib/core/log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/log.py
+++ b/lib/core/log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/optiondict.py
+++ b/lib/core/optiondict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/optiondict.py
+++ b/lib/core/optiondict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/profiling.py
+++ b/lib/core/profiling.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/profiling.py
+++ b/lib/core/profiling.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/readlineng.py
+++ b/lib/core/readlineng.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/readlineng.py
+++ b/lib/core/readlineng.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/replication.py
+++ b/lib/core/replication.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/replication.py
+++ b/lib/core/replication.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/revision.py
+++ b/lib/core/revision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/revision.py
+++ b/lib/core/revision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/session.py
+++ b/lib/core/session.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/session.py
+++ b/lib/core/session.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/shell.py
+++ b/lib/core/shell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/shell.py
+++ b/lib/core/shell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/subprocessng.py
+++ b/lib/core/subprocessng.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/subprocessng.py
+++ b/lib/core/subprocessng.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/testing.py
+++ b/lib/core/testing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/testing.py
+++ b/lib/core/testing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/threads.py
+++ b/lib/core/threads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/threads.py
+++ b/lib/core/threads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/unescaper.py
+++ b/lib/core/unescaper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/unescaper.py
+++ b/lib/core/unescaper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/update.py
+++ b/lib/core/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/update.py
+++ b/lib/core/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/wordlist.py
+++ b/lib/core/wordlist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/wordlist.py
+++ b/lib/core/wordlist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/core/xmldump.py
+++ b/lib/core/xmldump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import codecs
 import os

--- a/lib/core/xmldump.py
+++ b/lib/core/xmldump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 import codecs
 import os

--- a/lib/parse/__init__.py
+++ b/lib/parse/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/__init__.py
+++ b/lib/parse/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/banner.py
+++ b/lib/parse/banner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/banner.py
+++ b/lib/parse/banner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/configfile.py
+++ b/lib/parse/configfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/configfile.py
+++ b/lib/parse/configfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/handler.py
+++ b/lib/parse/handler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/handler.py
+++ b/lib/parse/handler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/headers.py
+++ b/lib/parse/headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/headers.py
+++ b/lib/parse/headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/html.py
+++ b/lib/parse/html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/html.py
+++ b/lib/parse/html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/payloads.py
+++ b/lib/parse/payloads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/payloads.py
+++ b/lib/parse/payloads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/sitemap.py
+++ b/lib/parse/sitemap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/parse/sitemap.py
+++ b/lib/parse/sitemap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/__init__.py
+++ b/lib/request/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/__init__.py
+++ b/lib/request/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/basic.py
+++ b/lib/request/basic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/basic.py
+++ b/lib/request/basic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/basicauthhandler.py
+++ b/lib/request/basicauthhandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/basicauthhandler.py
+++ b/lib/request/basicauthhandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/comparison.py
+++ b/lib/request/comparison.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/comparison.py
+++ b/lib/request/comparison.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/direct.py
+++ b/lib/request/direct.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/direct.py
+++ b/lib/request/direct.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/dns.py
+++ b/lib/request/dns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/dns.py
+++ b/lib/request/dns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/httpshandler.py
+++ b/lib/request/httpshandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/httpshandler.py
+++ b/lib/request/httpshandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/inject.py
+++ b/lib/request/inject.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/inject.py
+++ b/lib/request/inject.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/methodrequest.py
+++ b/lib/request/methodrequest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/methodrequest.py
+++ b/lib/request/methodrequest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/pkihandler.py
+++ b/lib/request/pkihandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/pkihandler.py
+++ b/lib/request/pkihandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/rangehandler.py
+++ b/lib/request/rangehandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/rangehandler.py
+++ b/lib/request/rangehandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/redirecthandler.py
+++ b/lib/request/redirecthandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/redirecthandler.py
+++ b/lib/request/redirecthandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/templates.py
+++ b/lib/request/templates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/request/templates.py
+++ b/lib/request/templates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)
@@ -19,4 +19,3 @@ def getPageTemplate(payload, place):
         retVal = kb.pageTemplates[(payload, place)]
 
     return retVal
-

--- a/lib/takeover/__init__.py
+++ b/lib/takeover/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/__init__.py
+++ b/lib/takeover/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/abstraction.py
+++ b/lib/takeover/abstraction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/abstraction.py
+++ b/lib/takeover/abstraction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/icmpsh.py
+++ b/lib/takeover/icmpsh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/icmpsh.py
+++ b/lib/takeover/icmpsh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/metasploit.py
+++ b/lib/takeover/metasploit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/metasploit.py
+++ b/lib/takeover/metasploit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/registry.py
+++ b/lib/takeover/registry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/registry.py
+++ b/lib/takeover/registry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/udf.py
+++ b/lib/takeover/udf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/udf.py
+++ b/lib/takeover/udf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/web.py
+++ b/lib/takeover/web.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/web.py
+++ b/lib/takeover/web.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/xp_cmdshell.py
+++ b/lib/takeover/xp_cmdshell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/takeover/xp_cmdshell.py
+++ b/lib/takeover/xp_cmdshell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/__init__.py
+++ b/lib/techniques/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/__init__.py
+++ b/lib/techniques/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/blind/__init__.py
+++ b/lib/techniques/blind/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/blind/__init__.py
+++ b/lib/techniques/blind/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/blind/inference.py
+++ b/lib/techniques/blind/inference.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/blind/inference.py
+++ b/lib/techniques/blind/inference.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/brute/__init__.py
+++ b/lib/techniques/brute/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/brute/__init__.py
+++ b/lib/techniques/brute/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/brute/use.py
+++ b/lib/techniques/brute/use.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/brute/use.py
+++ b/lib/techniques/brute/use.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/dns/__init__.py
+++ b/lib/techniques/dns/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/dns/__init__.py
+++ b/lib/techniques/dns/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/dns/test.py
+++ b/lib/techniques/dns/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/dns/test.py
+++ b/lib/techniques/dns/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/dns/use.py
+++ b/lib/techniques/dns/use.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/dns/use.py
+++ b/lib/techniques/dns/use.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/error/__init__.py
+++ b/lib/techniques/error/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/error/__init__.py
+++ b/lib/techniques/error/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/error/use.py
+++ b/lib/techniques/error/use.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/error/use.py
+++ b/lib/techniques/error/use.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/union/__init__.py
+++ b/lib/techniques/union/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/union/__init__.py
+++ b/lib/techniques/union/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/union/test.py
+++ b/lib/techniques/union/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/union/test.py
+++ b/lib/techniques/union/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/union/use.py
+++ b/lib/techniques/union/use.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/techniques/union/use.py
+++ b/lib/techniques/union/use.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/api.py
+++ b/lib/utils/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 
 """

--- a/lib/utils/api.py
+++ b/lib/utils/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 """

--- a/lib/utils/crawler.py
+++ b/lib/utils/crawler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/crawler.py
+++ b/lib/utils/crawler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/deps.py
+++ b/lib/utils/deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/deps.py
+++ b/lib/utils/deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)
@@ -95,4 +95,3 @@ def checkDependencies():
     if len(missing_libraries) == 0:
         infoMsg = "all dependencies are installed"
         logger.info(infoMsg)
-

--- a/lib/utils/getch.py
+++ b/lib/utils/getch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/getch.py
+++ b/lib/utils/getch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)
@@ -81,4 +81,3 @@ class _GetchMacCarbon(object):
 
 
 getch = _Getch()
-

--- a/lib/utils/google.py
+++ b/lib/utils/google.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/google.py
+++ b/lib/utils/google.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/hash.py
+++ b/lib/utils/hash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/hash.py
+++ b/lib/utils/hash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/hashdb.py
+++ b/lib/utils/hashdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/hashdb.py
+++ b/lib/utils/hashdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/htmlentities.py
+++ b/lib/utils/htmlentities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/htmlentities.py
+++ b/lib/utils/htmlentities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/pivotdumptable.py
+++ b/lib/utils/pivotdumptable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/pivotdumptable.py
+++ b/lib/utils/pivotdumptable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/progress.py
+++ b/lib/utils/progress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/progress.py
+++ b/lib/utils/progress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/purge.py
+++ b/lib/utils/purge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/purge.py
+++ b/lib/utils/purge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/sqlalchemy.py
+++ b/lib/utils/sqlalchemy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/sqlalchemy.py
+++ b/lib/utils/sqlalchemy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/timeout.py
+++ b/lib/utils/timeout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/timeout.py
+++ b/lib/utils/timeout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/versioncheck.py
+++ b/lib/utils/versioncheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/versioncheck.py
+++ b/lib/utils/versioncheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/xrange.py
+++ b/lib/utils/xrange.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/lib/utils/xrange.py
+++ b/lib/utils/xrange.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/__init__.py
+++ b/plugins/dbms/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/__init__.py
+++ b/plugins/dbms/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/__init__.py
+++ b/plugins/dbms/access/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/__init__.py
+++ b/plugins/dbms/access/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/connector.py
+++ b/plugins/dbms/access/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/connector.py
+++ b/plugins/dbms/access/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/enumeration.py
+++ b/plugins/dbms/access/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/enumeration.py
+++ b/plugins/dbms/access/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/filesystem.py
+++ b/plugins/dbms/access/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/filesystem.py
+++ b/plugins/dbms/access/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/fingerprint.py
+++ b/plugins/dbms/access/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/fingerprint.py
+++ b/plugins/dbms/access/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/syntax.py
+++ b/plugins/dbms/access/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/syntax.py
+++ b/plugins/dbms/access/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/takeover.py
+++ b/plugins/dbms/access/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/access/takeover.py
+++ b/plugins/dbms/access/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/__init__.py
+++ b/plugins/dbms/db2/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/__init__.py
+++ b/plugins/dbms/db2/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/connector.py
+++ b/plugins/dbms/db2/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/connector.py
+++ b/plugins/dbms/db2/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/enumeration.py
+++ b/plugins/dbms/db2/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/enumeration.py
+++ b/plugins/dbms/db2/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)
@@ -18,4 +18,3 @@ class Enumeration(GenericEnumeration):
         logger.warn(warnMsg)
 
         return {}
-

--- a/plugins/dbms/db2/filesystem.py
+++ b/plugins/dbms/db2/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/filesystem.py
+++ b/plugins/dbms/db2/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/fingerprint.py
+++ b/plugins/dbms/db2/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/fingerprint.py
+++ b/plugins/dbms/db2/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/syntax.py
+++ b/plugins/dbms/db2/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/syntax.py
+++ b/plugins/dbms/db2/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/takeover.py
+++ b/plugins/dbms/db2/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/db2/takeover.py
+++ b/plugins/dbms/db2/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/__init__.py
+++ b/plugins/dbms/firebird/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/__init__.py
+++ b/plugins/dbms/firebird/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/connector.py
+++ b/plugins/dbms/firebird/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/connector.py
+++ b/plugins/dbms/firebird/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/enumeration.py
+++ b/plugins/dbms/firebird/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/enumeration.py
+++ b/plugins/dbms/firebird/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/filesystem.py
+++ b/plugins/dbms/firebird/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/filesystem.py
+++ b/plugins/dbms/firebird/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/fingerprint.py
+++ b/plugins/dbms/firebird/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/fingerprint.py
+++ b/plugins/dbms/firebird/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/syntax.py
+++ b/plugins/dbms/firebird/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/syntax.py
+++ b/plugins/dbms/firebird/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/takeover.py
+++ b/plugins/dbms/firebird/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/firebird/takeover.py
+++ b/plugins/dbms/firebird/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/__init__.py
+++ b/plugins/dbms/hsqldb/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/__init__.py
+++ b/plugins/dbms/hsqldb/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/connector.py
+++ b/plugins/dbms/hsqldb/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/connector.py
+++ b/plugins/dbms/hsqldb/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/enumeration.py
+++ b/plugins/dbms/hsqldb/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/enumeration.py
+++ b/plugins/dbms/hsqldb/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/filesystem.py
+++ b/plugins/dbms/hsqldb/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/filesystem.py
+++ b/plugins/dbms/hsqldb/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/fingerprint.py
+++ b/plugins/dbms/hsqldb/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/fingerprint.py
+++ b/plugins/dbms/hsqldb/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/syntax.py
+++ b/plugins/dbms/hsqldb/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/syntax.py
+++ b/plugins/dbms/hsqldb/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/takeover.py
+++ b/plugins/dbms/hsqldb/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/hsqldb/takeover.py
+++ b/plugins/dbms/hsqldb/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/__init__.py
+++ b/plugins/dbms/maxdb/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/__init__.py
+++ b/plugins/dbms/maxdb/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/connector.py
+++ b/plugins/dbms/maxdb/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/connector.py
+++ b/plugins/dbms/maxdb/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/enumeration.py
+++ b/plugins/dbms/maxdb/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/enumeration.py
+++ b/plugins/dbms/maxdb/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/filesystem.py
+++ b/plugins/dbms/maxdb/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/filesystem.py
+++ b/plugins/dbms/maxdb/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/fingerprint.py
+++ b/plugins/dbms/maxdb/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/fingerprint.py
+++ b/plugins/dbms/maxdb/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/syntax.py
+++ b/plugins/dbms/maxdb/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/syntax.py
+++ b/plugins/dbms/maxdb/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/takeover.py
+++ b/plugins/dbms/maxdb/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/maxdb/takeover.py
+++ b/plugins/dbms/maxdb/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/__init__.py
+++ b/plugins/dbms/mssqlserver/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/__init__.py
+++ b/plugins/dbms/mssqlserver/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/connector.py
+++ b/plugins/dbms/mssqlserver/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/connector.py
+++ b/plugins/dbms/mssqlserver/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/enumeration.py
+++ b/plugins/dbms/mssqlserver/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/enumeration.py
+++ b/plugins/dbms/mssqlserver/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/filesystem.py
+++ b/plugins/dbms/mssqlserver/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/filesystem.py
+++ b/plugins/dbms/mssqlserver/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/fingerprint.py
+++ b/plugins/dbms/mssqlserver/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/fingerprint.py
+++ b/plugins/dbms/mssqlserver/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/syntax.py
+++ b/plugins/dbms/mssqlserver/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/syntax.py
+++ b/plugins/dbms/mssqlserver/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/takeover.py
+++ b/plugins/dbms/mssqlserver/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mssqlserver/takeover.py
+++ b/plugins/dbms/mssqlserver/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/__init__.py
+++ b/plugins/dbms/mysql/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/__init__.py
+++ b/plugins/dbms/mysql/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/connector.py
+++ b/plugins/dbms/mysql/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/connector.py
+++ b/plugins/dbms/mysql/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/enumeration.py
+++ b/plugins/dbms/mysql/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/enumeration.py
+++ b/plugins/dbms/mysql/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/filesystem.py
+++ b/plugins/dbms/mysql/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/filesystem.py
+++ b/plugins/dbms/mysql/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/fingerprint.py
+++ b/plugins/dbms/mysql/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/fingerprint.py
+++ b/plugins/dbms/mysql/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/syntax.py
+++ b/plugins/dbms/mysql/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/syntax.py
+++ b/plugins/dbms/mysql/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/takeover.py
+++ b/plugins/dbms/mysql/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/mysql/takeover.py
+++ b/plugins/dbms/mysql/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/__init__.py
+++ b/plugins/dbms/oracle/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/__init__.py
+++ b/plugins/dbms/oracle/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/connector.py
+++ b/plugins/dbms/oracle/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/connector.py
+++ b/plugins/dbms/oracle/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/enumeration.py
+++ b/plugins/dbms/oracle/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/enumeration.py
+++ b/plugins/dbms/oracle/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/filesystem.py
+++ b/plugins/dbms/oracle/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/filesystem.py
+++ b/plugins/dbms/oracle/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/fingerprint.py
+++ b/plugins/dbms/oracle/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/fingerprint.py
+++ b/plugins/dbms/oracle/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/syntax.py
+++ b/plugins/dbms/oracle/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/syntax.py
+++ b/plugins/dbms/oracle/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/takeover.py
+++ b/plugins/dbms/oracle/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/oracle/takeover.py
+++ b/plugins/dbms/oracle/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/__init__.py
+++ b/plugins/dbms/postgresql/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/__init__.py
+++ b/plugins/dbms/postgresql/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/connector.py
+++ b/plugins/dbms/postgresql/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/connector.py
+++ b/plugins/dbms/postgresql/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/enumeration.py
+++ b/plugins/dbms/postgresql/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/enumeration.py
+++ b/plugins/dbms/postgresql/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/filesystem.py
+++ b/plugins/dbms/postgresql/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/filesystem.py
+++ b/plugins/dbms/postgresql/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/fingerprint.py
+++ b/plugins/dbms/postgresql/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/fingerprint.py
+++ b/plugins/dbms/postgresql/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/syntax.py
+++ b/plugins/dbms/postgresql/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/syntax.py
+++ b/plugins/dbms/postgresql/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/takeover.py
+++ b/plugins/dbms/postgresql/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/postgresql/takeover.py
+++ b/plugins/dbms/postgresql/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/__init__.py
+++ b/plugins/dbms/sqlite/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/__init__.py
+++ b/plugins/dbms/sqlite/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/connector.py
+++ b/plugins/dbms/sqlite/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/connector.py
+++ b/plugins/dbms/sqlite/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/enumeration.py
+++ b/plugins/dbms/sqlite/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/enumeration.py
+++ b/plugins/dbms/sqlite/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/filesystem.py
+++ b/plugins/dbms/sqlite/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/filesystem.py
+++ b/plugins/dbms/sqlite/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/fingerprint.py
+++ b/plugins/dbms/sqlite/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/fingerprint.py
+++ b/plugins/dbms/sqlite/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/syntax.py
+++ b/plugins/dbms/sqlite/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/syntax.py
+++ b/plugins/dbms/sqlite/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/takeover.py
+++ b/plugins/dbms/sqlite/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sqlite/takeover.py
+++ b/plugins/dbms/sqlite/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/__init__.py
+++ b/plugins/dbms/sybase/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/__init__.py
+++ b/plugins/dbms/sybase/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/connector.py
+++ b/plugins/dbms/sybase/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/connector.py
+++ b/plugins/dbms/sybase/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/enumeration.py
+++ b/plugins/dbms/sybase/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/enumeration.py
+++ b/plugins/dbms/sybase/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/filesystem.py
+++ b/plugins/dbms/sybase/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/filesystem.py
+++ b/plugins/dbms/sybase/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/fingerprint.py
+++ b/plugins/dbms/sybase/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/fingerprint.py
+++ b/plugins/dbms/sybase/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/syntax.py
+++ b/plugins/dbms/sybase/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/syntax.py
+++ b/plugins/dbms/sybase/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/takeover.py
+++ b/plugins/dbms/sybase/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/dbms/sybase/takeover.py
+++ b/plugins/dbms/sybase/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/__init__.py
+++ b/plugins/generic/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/__init__.py
+++ b/plugins/generic/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/connector.py
+++ b/plugins/generic/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/connector.py
+++ b/plugins/generic/connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/custom.py
+++ b/plugins/generic/custom.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/custom.py
+++ b/plugins/generic/custom.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/databases.py
+++ b/plugins/generic/databases.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/databases.py
+++ b/plugins/generic/databases.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/entries.py
+++ b/plugins/generic/entries.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/entries.py
+++ b/plugins/generic/entries.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/enumeration.py
+++ b/plugins/generic/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/enumeration.py
+++ b/plugins/generic/enumeration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/filesystem.py
+++ b/plugins/generic/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/filesystem.py
+++ b/plugins/generic/filesystem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/fingerprint.py
+++ b/plugins/generic/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/fingerprint.py
+++ b/plugins/generic/fingerprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/misc.py
+++ b/plugins/generic/misc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/misc.py
+++ b/plugins/generic/misc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/search.py
+++ b/plugins/generic/search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/search.py
+++ b/plugins/generic/search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/syntax.py
+++ b/plugins/generic/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/syntax.py
+++ b/plugins/generic/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/takeover.py
+++ b/plugins/generic/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/takeover.py
+++ b/plugins/generic/takeover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/users.py
+++ b/plugins/generic/users.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/plugins/generic/users.py
+++ b/plugins/generic/users.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/sqlmap.py
+++ b/sqlmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/sqlmap.py
+++ b/sqlmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/sqlmapapi.py
+++ b/sqlmapapi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/sqlmapapi.py
+++ b/sqlmapapi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/__init__.py
+++ b/tamper/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/__init__.py
+++ b/tamper/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/apostrophemask.py
+++ b/tamper/apostrophemask.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/apostrophemask.py
+++ b/tamper/apostrophemask.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/apostrophenullencode.py
+++ b/tamper/apostrophenullencode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/apostrophenullencode.py
+++ b/tamper/apostrophenullencode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/appendnullbyte.py
+++ b/tamper/appendnullbyte.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/appendnullbyte.py
+++ b/tamper/appendnullbyte.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/base64encode.py
+++ b/tamper/base64encode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/base64encode.py
+++ b/tamper/base64encode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/between.py
+++ b/tamper/between.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/between.py
+++ b/tamper/between.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/bluecoat.py
+++ b/tamper/bluecoat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/bluecoat.py
+++ b/tamper/bluecoat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/chardoubleencode.py
+++ b/tamper/chardoubleencode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/chardoubleencode.py
+++ b/tamper/chardoubleencode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/charencode.py
+++ b/tamper/charencode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/charencode.py
+++ b/tamper/charencode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/charunicodeencode.py
+++ b/tamper/charunicodeencode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/charunicodeencode.py
+++ b/tamper/charunicodeencode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/concat2concatws.py
+++ b/tamper/concat2concatws.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/concat2concatws.py
+++ b/tamper/concat2concatws.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/equaltolike.py
+++ b/tamper/equaltolike.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/equaltolike.py
+++ b/tamper/equaltolike.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/greatest.py
+++ b/tamper/greatest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/greatest.py
+++ b/tamper/greatest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/halfversionedmorekeywords.py
+++ b/tamper/halfversionedmorekeywords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/halfversionedmorekeywords.py
+++ b/tamper/halfversionedmorekeywords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/ifnull2ifisnull.py
+++ b/tamper/ifnull2ifisnull.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/ifnull2ifisnull.py
+++ b/tamper/ifnull2ifisnull.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/informationschemacomment.py
+++ b/tamper/informationschemacomment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/informationschemacomment.py
+++ b/tamper/informationschemacomment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/lowercase.py
+++ b/tamper/lowercase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/lowercase.py
+++ b/tamper/lowercase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/modsecurityversioned.py
+++ b/tamper/modsecurityversioned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/modsecurityversioned.py
+++ b/tamper/modsecurityversioned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/modsecurityzeroversioned.py
+++ b/tamper/modsecurityzeroversioned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/modsecurityzeroversioned.py
+++ b/tamper/modsecurityzeroversioned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/multiplespaces.py
+++ b/tamper/multiplespaces.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/multiplespaces.py
+++ b/tamper/multiplespaces.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/nonrecursivereplacement.py
+++ b/tamper/nonrecursivereplacement.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/nonrecursivereplacement.py
+++ b/tamper/nonrecursivereplacement.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/overlongutf8.py
+++ b/tamper/overlongutf8.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/overlongutf8.py
+++ b/tamper/overlongutf8.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/percentage.py
+++ b/tamper/percentage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/percentage.py
+++ b/tamper/percentage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/randomcase.py
+++ b/tamper/randomcase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/randomcase.py
+++ b/tamper/randomcase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/randomcomments.py
+++ b/tamper/randomcomments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/randomcomments.py
+++ b/tamper/randomcomments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/securesphere.py
+++ b/tamper/securesphere.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/securesphere.py
+++ b/tamper/securesphere.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/sp_password.py
+++ b/tamper/sp_password.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/sp_password.py
+++ b/tamper/sp_password.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2comment.py
+++ b/tamper/space2comment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2comment.py
+++ b/tamper/space2comment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2dash.py
+++ b/tamper/space2dash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2dash.py
+++ b/tamper/space2dash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2hash.py
+++ b/tamper/space2hash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2hash.py
+++ b/tamper/space2hash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2morehash.py
+++ b/tamper/space2morehash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2morehash.py
+++ b/tamper/space2morehash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2mssqlblank.py
+++ b/tamper/space2mssqlblank.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2mssqlblank.py
+++ b/tamper/space2mssqlblank.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2mssqlhash.py
+++ b/tamper/space2mssqlhash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2mssqlhash.py
+++ b/tamper/space2mssqlhash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2mysqlblank.py
+++ b/tamper/space2mysqlblank.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2mysqlblank.py
+++ b/tamper/space2mysqlblank.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2mysqldash.py
+++ b/tamper/space2mysqldash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2mysqldash.py
+++ b/tamper/space2mysqldash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2plus.py
+++ b/tamper/space2plus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2plus.py
+++ b/tamper/space2plus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2randomblank.py
+++ b/tamper/space2randomblank.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/space2randomblank.py
+++ b/tamper/space2randomblank.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/unionalltounion.py
+++ b/tamper/unionalltounion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/unionalltounion.py
+++ b/tamper/unionalltounion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/unmagicquotes.py
+++ b/tamper/unmagicquotes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/unmagicquotes.py
+++ b/tamper/unmagicquotes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/varnish.py
+++ b/tamper/varnish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/varnish.py
+++ b/tamper/varnish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/versionedkeywords.py
+++ b/tamper/versionedkeywords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/versionedkeywords.py
+++ b/tamper/versionedkeywords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/versionedmorekeywords.py
+++ b/tamper/versionedmorekeywords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/versionedmorekeywords.py
+++ b/tamper/versionedmorekeywords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/xforwardedfor.py
+++ b/tamper/xforwardedfor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/tamper/xforwardedfor.py
+++ b/tamper/xforwardedfor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/thirdparty/beautifulsoup/__init__.py
+++ b/thirdparty/beautifulsoup/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # 
 # Copyright (c) 2004-2010, Leonard Richardson
 # 

--- a/thirdparty/beautifulsoup/__init__.py
+++ b/thirdparty/beautifulsoup/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 # 
 # Copyright (c) 2004-2010, Leonard Richardson
 # 

--- a/thirdparty/bottle/__init__.py
+++ b/thirdparty/bottle/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/thirdparty/bottle/__init__.py
+++ b/thirdparty/bottle/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/thirdparty/bottle/bottle.py
+++ b/thirdparty/bottle/bottle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 """
 Bottle is a fast and simple micro-framework for small web applications. It

--- a/thirdparty/bottle/bottle.py
+++ b/thirdparty/bottle/bottle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
 Bottle is a fast and simple micro-framework for small web applications. It

--- a/thirdparty/clientform/__init__.py
+++ b/thirdparty/clientform/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # Copyright 2007-2008 David McNab
 #

--- a/thirdparty/clientform/__init__.py
+++ b/thirdparty/clientform/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2007-2008 David McNab
 #

--- a/thirdparty/fcrypt/__init__.py
+++ b/thirdparty/fcrypt/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 #Copyright (c) 2004, Carey Evans <careye@spamcop.net>
 #All rights reserved.

--- a/thirdparty/fcrypt/__init__.py
+++ b/thirdparty/fcrypt/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 #Copyright (c) 2004, Carey Evans <careye@spamcop.net>
 #All rights reserved.

--- a/thirdparty/gprof2dot/__init__.py
+++ b/thirdparty/gprof2dot/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # Copyright 2008-2009 Jose Fonseca
 #

--- a/thirdparty/gprof2dot/__init__.py
+++ b/thirdparty/gprof2dot/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2008-2009 Jose Fonseca
 #

--- a/thirdparty/gprof2dot/gprof2dot.py
+++ b/thirdparty/gprof2dot/gprof2dot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # Copyright 2008-2009 Jose Fonseca
 #

--- a/thirdparty/gprof2dot/gprof2dot.py
+++ b/thirdparty/gprof2dot/gprof2dot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2008-2009 Jose Fonseca
 #

--- a/thirdparty/keepalive/__init__.py
+++ b/thirdparty/keepalive/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # Copyright 2002-2003 Michael D. Stenner
 #

--- a/thirdparty/keepalive/__init__.py
+++ b/thirdparty/keepalive/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2002-2003 Michael D. Stenner
 #

--- a/thirdparty/keepalive/keepalive.py
+++ b/thirdparty/keepalive/keepalive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # Copyright 2002-2003 Michael D. Stenner
 #

--- a/thirdparty/keepalive/keepalive.py
+++ b/thirdparty/keepalive/keepalive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2002-2003 Michael D. Stenner
 #

--- a/thirdparty/multipart/multipartpost.py
+++ b/thirdparty/multipart/multipartpost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 02/2006 Will Holcomb <wholcomb@gmail.com>

--- a/thirdparty/multipart/multipartpost.py
+++ b/thirdparty/multipart/multipartpost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 02/2006 Will Holcomb <wholcomb@gmail.com>

--- a/thirdparty/odict/__init__.py
+++ b/thirdparty/odict/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # The BSD License
 #

--- a/thirdparty/odict/__init__.py
+++ b/thirdparty/odict/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # The BSD License
 #

--- a/thirdparty/oset/_abc.py
+++ b/thirdparty/oset/_abc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # -*- mode:python; tab-width: 2; coding: utf-8 -*-
 
 """Partially backported python ABC classes"""

--- a/thirdparty/oset/_abc.py
+++ b/thirdparty/oset/_abc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 # -*- mode:python; tab-width: 2; coding: utf-8 -*-
 
 """Partially backported python ABC classes"""

--- a/thirdparty/oset/pyoset.py
+++ b/thirdparty/oset/pyoset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # -*- mode:python; tab-width: 2; coding: utf-8 -*-
 
 """Partially backported python ABC classes"""

--- a/thirdparty/oset/pyoset.py
+++ b/thirdparty/oset/pyoset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 # -*- mode:python; tab-width: 2; coding: utf-8 -*-
 
 """Partially backported python ABC classes"""

--- a/thirdparty/pagerank/__init__.py
+++ b/thirdparty/pagerank/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # The MIT License
 #

--- a/thirdparty/pagerank/__init__.py
+++ b/thirdparty/pagerank/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # The MIT License
 #

--- a/thirdparty/pagerank/pagerank.py
+++ b/thirdparty/pagerank/pagerank.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 #  Script for getting Google Page Rank of page
 #  Google Toolbar 3.0.x/4.0.x Pagerank Checksum Algorithm

--- a/thirdparty/pagerank/pagerank.py
+++ b/thirdparty/pagerank/pagerank.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 #  Script for getting Google Page Rank of page
 #  Google Toolbar 3.0.x/4.0.x Pagerank Checksum Algorithm

--- a/thirdparty/prettyprint/__init__.py
+++ b/thirdparty/prettyprint/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 #Copyright (c) 2010, Chris Hall <chris.hall@mod10.net>
 #All rights reserved.

--- a/thirdparty/prettyprint/__init__.py
+++ b/thirdparty/prettyprint/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 #Copyright (c) 2010, Chris Hall <chris.hall@mod10.net>
 #All rights reserved.

--- a/thirdparty/prettyprint/prettyprint.py
+++ b/thirdparty/prettyprint/prettyprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 #Copyright (c) 2010, Chris Hall <chris.hall@mod10.net>
 #All rights reserved.

--- a/thirdparty/prettyprint/prettyprint.py
+++ b/thirdparty/prettyprint/prettyprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 #Copyright (c) 2010, Chris Hall <chris.hall@mod10.net>
 #All rights reserved.

--- a/thirdparty/pydes/__init__.py
+++ b/thirdparty/pydes/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # Copyright 2009 Todd Whiteman
 #

--- a/thirdparty/pydes/__init__.py
+++ b/thirdparty/pydes/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2009 Todd Whiteman
 #

--- a/thirdparty/socks/socks.py
+++ b/thirdparty/socks/socks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """SocksiPy - Python SOCKS module.
 Version 1.00

--- a/thirdparty/socks/socks.py
+++ b/thirdparty/socks/socks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """SocksiPy - Python SOCKS module.
 Version 1.00

--- a/thirdparty/xdot/__init__.py
+++ b/thirdparty/xdot/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # Copyright 2008-2009 Jose Fonseca
 #

--- a/thirdparty/xdot/__init__.py
+++ b/thirdparty/xdot/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2008-2009 Jose Fonseca
 #

--- a/thirdparty/xdot/xdot.py
+++ b/thirdparty/xdot/xdot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 #
 # Copyright 2008 Jose Fonseca
 #

--- a/thirdparty/xdot/xdot.py
+++ b/thirdparty/xdot/xdot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2008 Jose Fonseca
 #

--- a/waf/360.py
+++ b/waf/360.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/360.py
+++ b/waf/360.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/__init__.py
+++ b/waf/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/__init__.py
+++ b/waf/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/airlock.py
+++ b/waf/airlock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/airlock.py
+++ b/waf/airlock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/anquanbao.py
+++ b/waf/anquanbao.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/anquanbao.py
+++ b/waf/anquanbao.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/baidu.py
+++ b/waf/baidu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/baidu.py
+++ b/waf/baidu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/barracuda.py
+++ b/waf/barracuda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/barracuda.py
+++ b/waf/barracuda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/bigip.py
+++ b/waf/bigip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/bigip.py
+++ b/waf/bigip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/binarysec.py
+++ b/waf/binarysec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/binarysec.py
+++ b/waf/binarysec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/blockdos.py
+++ b/waf/blockdos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/blockdos.py
+++ b/waf/blockdos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/ciscoacexml.py
+++ b/waf/ciscoacexml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/ciscoacexml.py
+++ b/waf/ciscoacexml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/cloudflare.py
+++ b/waf/cloudflare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/cloudflare.py
+++ b/waf/cloudflare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/datapower.py
+++ b/waf/datapower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/datapower.py
+++ b/waf/datapower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/denyall.py
+++ b/waf/denyall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/denyall.py
+++ b/waf/denyall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/dotdefender.py
+++ b/waf/dotdefender.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/dotdefender.py
+++ b/waf/dotdefender.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/edgecast.py
+++ b/waf/edgecast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/edgecast.py
+++ b/waf/edgecast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/expressionengine.py
+++ b/waf/expressionengine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/expressionengine.py
+++ b/waf/expressionengine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/fortiweb.py
+++ b/waf/fortiweb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/fortiweb.py
+++ b/waf/fortiweb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/hyperguard.py
+++ b/waf/hyperguard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/hyperguard.py
+++ b/waf/hyperguard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/incapsula.py
+++ b/waf/incapsula.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/incapsula.py
+++ b/waf/incapsula.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/isaserver.py
+++ b/waf/isaserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/isaserver.py
+++ b/waf/isaserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/jiasule.py
+++ b/waf/jiasule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/jiasule.py
+++ b/waf/jiasule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/knownsec.py
+++ b/waf/knownsec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/knownsec.py
+++ b/waf/knownsec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/kona.py
+++ b/waf/kona.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/kona.py
+++ b/waf/kona.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/modsecurity.py
+++ b/waf/modsecurity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/modsecurity.py
+++ b/waf/modsecurity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/netcontinuum.py
+++ b/waf/netcontinuum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/netcontinuum.py
+++ b/waf/netcontinuum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/netscaler.py
+++ b/waf/netscaler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/netscaler.py
+++ b/waf/netscaler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/paloalto.py
+++ b/waf/paloalto.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/paloalto.py
+++ b/waf/paloalto.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/profense.py
+++ b/waf/profense.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/profense.py
+++ b/waf/profense.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/proventia.py
+++ b/waf/proventia.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/proventia.py
+++ b/waf/proventia.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/radware.py
+++ b/waf/radware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/radware.py
+++ b/waf/radware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/requestvalidationmode.py
+++ b/waf/requestvalidationmode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/requestvalidationmode.py
+++ b/waf/requestvalidationmode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/safedog.py
+++ b/waf/safedog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/safedog.py
+++ b/waf/safedog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/secureiis.py
+++ b/waf/secureiis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/secureiis.py
+++ b/waf/secureiis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/senginx.py
+++ b/waf/senginx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/senginx.py
+++ b/waf/senginx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/sucuri.py
+++ b/waf/sucuri.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/sucuri.py
+++ b/waf/sucuri.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/teros.py
+++ b/waf/teros.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/teros.py
+++ b/waf/teros.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/trafficshield.py
+++ b/waf/trafficshield.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/trafficshield.py
+++ b/waf/trafficshield.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/urlscan.py
+++ b/waf/urlscan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/urlscan.py
+++ b/waf/urlscan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/uspses.py
+++ b/waf/uspses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/uspses.py
+++ b/waf/uspses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/varnish.py
+++ b/waf/varnish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/varnish.py
+++ b/waf/varnish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/webappsecure.py
+++ b/waf/webappsecure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/webappsecure.py
+++ b/waf/webappsecure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/webknight.py
+++ b/waf/webknight.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)

--- a/waf/webknight.py
+++ b/waf/webknight.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2006-2015 sqlmap developers (http://sqlmap.org/)


### PR DESCRIPTION
I installed sqlmap on my Arch Linux and cannot run it using `./sqlmap.py`
sqlmap uses `#!/usr/bin/env python` who's `Python 3` on my installation...

This commit change every `python` to `python2`.

Reference : https://github.com/sqlmapproject/sqlmap/pull/1244