### PR TITLE
Handle non-alnum parameters with --eval

### DIFF
--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -611,6 +611,9 @@ MIN_ENCODED_LEN_CHECK = 5
 # Timeout in seconds in which Metasploit remote session has to be initialized
 METASPLOIT_SESSION_TIMEOUT = 300
 
+# Replacement for non-ALNUM chars in variables
+EVALCODE_NONALNUM_REP = "_%s_"  # %s to be changed for hex(ord(char))
+
 # Suffix used to mark variables having keyword names
 EVALCODE_KEYWORD_SUFFIX = "_KEYWORD"
 


### PR DESCRIPTION
When using `--eval` to edit some parameters using some custom Python code, it is not possible to edit some parameters, for example containing dots (`foo.bar`). Currently, non-alnum chars are deleted before the custom Python code is evaluated, and are not put back afterwards.

There is already code in place to handle the cases where the parameters are Python keywords (e.g. `if`), by appending the suffix `_KEYWORD` to them (`EVALCODE_KEYWORD_SUFFIX`). This means that we can edit the `if_KEYWORD` Python variable instead of `if`.

The idea of this PR is to do something similar with non-alnum (`[^\w]`) chars in parameters. Each non-alnum char is replaced by a delimiter, can then be modified in the Python code (the one passed using `--eval`) and then replaced back to the original parameter.

Here are some examples with the implementation of this PR:

| Original parameter | As seen from `--eval`'s Python code | Comment |
| --- | --- | --- |
| `foo` | `foo` | Nothing changed |
| `foo_bar` | `foo_bar` | Nothing changed |
| `foo.bar` | `foo_0x2e_bar` | Dot escaped |
| `_0x42_0x43_` | `_0x5f_0x42_0x5f_0x43_` | Multiple escapes to avoid being replaced back to `B0x43_` or `_0x42C` |
| `café` | `caf_0xc3__0xa9_` | Non-ASCII chars are also handled |

I hope everything makes sense, please ask questions if it's not the case!
