### PR TITLE
Add --crawl-file option to specify output filename

### DIFF
--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -508,7 +508,9 @@ def _setResultsFile():
         return
 
     if not conf.resultsFP:
-        conf.resultsFilename = os.path.join(paths.SQLMAP_OUTPUT_PATH, time.strftime(RESULTS_FILE_FORMAT).lower())
+        if not len(conf.resultsFilename):
+            conf.resultsFilename = os.path.join(paths.SQLMAP_OUTPUT_PATH, time.strftime(RESULTS_FILE_FORMAT).lower())
+        
         try:
             conf.resultsFP = openFile(conf.resultsFilename, "w+", UNICODE_ENCODING, buffering=0)
         except (OSError, IOError), ex:

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -610,7 +610,7 @@ def cmdLineParser():
                             help="Log all HTTP traffic into a "
                             "textual file")
 
-        general.add_option("--crawl-file", dest="batchCrawlFile", action="store",
+        general.add_option("--crawl-file", dest="crawlFile", action="store",
                             help="Destination file for crawled links")
 
         general.add_option("--batch", dest="batch",

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -610,6 +610,9 @@ def cmdLineParser():
                             help="Log all HTTP traffic into a "
                             "textual file")
 
+        general.add_option("--crawl-file", dest="batchCrawlFile", action="store",
+                            help="Destination file for crawled links")
+
         general.add_option("--batch", dest="batch",
                             action="store_true",
                             help="Never ask for user input, use the default behaviour")

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -613,6 +613,9 @@ def cmdLineParser():
         general.add_option("--crawl-file", dest="crawlFile", action="store",
                             help="Destination file for crawled links")
 
+        general.add_option("--results-file", dest="resultsFilename", action="store",
+                            help="Destination file for results in multi-target mode")
+
         general.add_option("--batch", dest="batch",
                             action="store_true",
                             help="Never ask for user input, use the default behaviour")

--- a/lib/utils/crawler.py
+++ b/lib/utils/crawler.py
@@ -186,12 +186,14 @@ def storeResultsToFile(results):
         test = readInput(message, default="N")
         kb.storeCrawlingChoice = test[0] in ("y", "Y")
 
-    if kb.storeCrawlingChoice:
-        handle, filename = tempfile.mkstemp(prefix="sqlmapcrawling-", suffix=".csv" if conf.forms else ".txt")
-        os.close(handle)
-
-        infoMsg = "writing crawling results to a temporary file '%s' " % filename
-        logger.info(infoMsg)
+    if kb.storeCrawlingChoice or conf.batchCrawlFile:
+        if conf.batchCrawlFile:
+            filename = conf.batchCrawlFile
+        else:
+            handle, filename = tempfile.mkstemp(prefix="sqlmapcrawling-", suffix=".csv" if conf.forms else ".txt")
+            os.close(handle)
+            infoMsg = "writing crawling results to a temporary file '%s' " % filename
+            logger.info(infoMsg)
 
         with openFile(filename, "w+b") as f:
             if conf.forms:

--- a/lib/utils/crawler.py
+++ b/lib/utils/crawler.py
@@ -186,9 +186,9 @@ def storeResultsToFile(results):
         test = readInput(message, default="N")
         kb.storeCrawlingChoice = test[0] in ("y", "Y")
 
-    if kb.storeCrawlingChoice or conf.batchCrawlFile:
-        if conf.batchCrawlFile:
-            filename = conf.batchCrawlFile
+    if kb.storeCrawlingChoice or conf.crawlFile:
+        if conf.crawlFile:
+            filename = conf.crawlFile
         else:
             handle, filename = tempfile.mkstemp(prefix="sqlmapcrawling-", suffix=".csv" if conf.forms else ".txt")
             os.close(handle)


### PR DESCRIPTION
Currently, there is no way to explicitly set the output file of crawling results.  For some automated tooling utilizing that feature, it is a bit more convenient to be able to control the output file name.