### PR TITLE
fixed open pipe and zoombie problems

### DIFF
--- a/lib/utils/api.py
+++ b/lib/utils/api.py
@@ -155,11 +155,12 @@ class Task(object):
 
     def engine_start(self):
         self.process = Popen(["python", "sqlmap.py", "--pickled-options", base64pickle(self.options)],
-                             shell=False, stdin=PIPE, close_fds=not IS_WIN)
+                             shell=False, close_fds=not IS_WIN)
 
     def engine_stop(self):
         if self.process:
-            return self.process.terminate()
+            self.process.terminate()
+            return self.process.wait()
         else:
             return None
 
@@ -168,7 +169,8 @@ class Task(object):
 
     def engine_kill(self):
         if self.process:
-            return self.process.kill()
+            self.process.kill()
+            return self.process.wait()
         else:
             return None
 


### PR DESCRIPTION
1. I have been working on issue #1292, I think this issue was due to too many useless pipe have been opened. So I try to remove `stdin=PIPE` in `engine_start()`, this issue never happens again.

2. We use `scan/taskid/stop`\\`kill` to terminate some overtime tasks, they turned out to become zoombie processes, everything works fine after we add `wait()` in those two apis.