### PR TITLE
Fix for #1341

### DIFF
--- a/lib/core/convert.py
+++ b/lib/core/convert.py
@@ -12,6 +12,7 @@ import sys
 
 from lib.core.settings import IS_WIN
 from lib.core.settings import UNICODE_ENCODING
+from lib.core.data import logger
 
 def base64decode(value):
     """
@@ -21,7 +22,16 @@ def base64decode(value):
     'foobar'
     """
 
-    return base64.b64decode(value)
+    retVal = None
+
+    try:
+        retVal = base64.b64decode(value)
+    except:
+        errMsg = "Invalid Base64 string"
+        logger.error(errMsg)
+        exit()
+    
+    return retVal
 
 def base64encode(value):
     """
@@ -71,6 +81,10 @@ def base64unpickle(value):
         retVal = pickle.loads(base64decode(value))
     except TypeError: 
         retVal = pickle.loads(base64decode(bytes(value)))
+    except:
+        errMsg = "Cannot deserialize object"
+        logger.error(errMsg)
+        exit()
 
     return retVal
 


### PR DESCRIPTION
Added try-except to catch exception when base64 string is not valid and cannot be decoded.
Also fixed unreporeted bug. Added another try-except to catch exception when object cannot be deserialized from pickle (base64 string is valid but it is not pickle-deserializable object after base64 decode)