### PR TITLE
Add support for --rw-dirs <rwDirs> cmd line argumant / conf file option

### DIFF
--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -566,6 +566,11 @@ def cmdLineParser():
                             help="Remote absolute path of temporary files "
                                  "directory")
 
+        takeover.add_option("--rw-dirs", dest="rwDirs",
+                            help="Remote absolute path of writable "
+                                 "directories for overriding defaults "
+                                 "(comma separated if multiple)")
+
         # Windows registry options
         windows = OptionGroup(parser, "Windows registry access", "These "
                                "options can be used to access the back-end "

--- a/lib/takeover/web.py
+++ b/lib/takeover/web.py
@@ -197,7 +197,13 @@ class Web:
                 self.webApi = choices[int(choice) - 1]
                 break
 
-        directories = list(arrayizeValue(getManualDirectories()))
+        # If specified in the conf file/cmd line then use those, else ask/use defaults for them
+        if conf.rwDirs:
+            logger.info("Trying to upload to user supplied dirs: %s" % conf.rwDirs)
+            directories = conf.rwDirs.split(',')
+        else:
+            directories = list(arrayizeValue(getManualDirectories()))
+
         directories.extend(getAutoDirectories())
         directories = list(oset(directories))
 

--- a/sqlmap.conf
+++ b/sqlmap.conf
@@ -606,6 +606,12 @@ msfPath =
 # Valid: absolute file system path
 tmpPath = 
 
+# Remote absolute path of writable directories
+# for overriding defaults (comma separated if
+# multiple)
+# E.g.: /var/www/html/uploads,/var/www/wordpress/images
+rwDirs = 
+
 
 # These options can be used to access the back-end database management
 # system Windows registry.


### PR DESCRIPTION
This allows one to fully automate commands where the default
upload directories cannot be used, as in:

$ sqlmap --batch --rw-dirs='/var/www/html/uploads' --os-cmd="ls;id" \
	-u 'http://nullbyte/kzMb5nVYJw/420search.php?usrtosearch=ramses'