### PR TITLE
Added commands stop, kill, list to API client

### DIFF
--- a/lib/utils/api.py
+++ b/lib/utils/api.py
@@ -698,12 +698,12 @@ def client(host=RESTAPI_SERVER_HOST, port=RESTAPI_SERVER_PORT):
 
     while True:
         try:
-            command = raw_input("api%s> " % (" (%s)" % taskid if taskid else "")).strip()
+            command = raw_input("api%s> " % (" (%s)" % taskid if taskid else "")).strip().lower()
         except (EOFError, KeyboardInterrupt):
             print
             break
 
-        if command.lower() in ("data", "log", "status", "stop", "kill"):
+        if command in ("data", "log", "status", "stop", "kill"):
             if not taskid:
                 logger.error("No task ID in use")
                 continue
@@ -713,7 +713,7 @@ def client(host=RESTAPI_SERVER_HOST, port=RESTAPI_SERVER_PORT):
                 logger.error("Failed to execute command " + command)
             dataToStdout("%s\n" % raw)
 
-        elif command.lower().startswith("new"):
+        elif command.startswith("new"):
             if ' ' not in command:
                 logger.error("Program arguments are missing")
                 continue
@@ -745,7 +745,7 @@ def client(host=RESTAPI_SERVER_HOST, port=RESTAPI_SERVER_PORT):
                 continue
             logger.info("Scanning started")
 
-        elif command.lower().startswith("use"):
+        elif command.startswith("use"):
             taskid = (command.split()[1] if ' ' in command else "").strip("'\"")
             if not taskid:
                 logger.error("Task ID is missing")
@@ -757,17 +757,17 @@ def client(host=RESTAPI_SERVER_HOST, port=RESTAPI_SERVER_PORT):
                 continue
             logger.info("Switching to task ID '%s' " % taskid)
 
-        elif command.lower() == "list":
-            raw = _client(addr + "/admin/0/list")
+        elif command in ("list", "flush"):
+            raw = _client(addr + "/admin/0/" + command)
             res = dejsonize(raw)
             if not res["success"]:
                 logger.error("Failed to execute command " + command)
             dataToStdout("%s\n" % raw)
 
-        elif command.lower() in ("exit", "bye", "quit", 'q'):
+        elif command in ("exit", "bye", "quit", 'q'):
             return
 
-        elif command.lower() in ("help", "?"):
+        elif command in ("help", "?"):
             msg =  "help        Show this help message\n"
             msg += "new ARGS    Start a new scan task with provided arguments (e.g. 'new -u \"http://testphp.vulnweb.com/artists.php?artist=1\"')\n"
             msg += "use TASKID  Switch current context to different task (e.g. 'use c04d8c5c7582efb4')\n"
@@ -777,6 +777,7 @@ def client(host=RESTAPI_SERVER_HOST, port=RESTAPI_SERVER_PORT):
             msg += "stop        Stop current task\n"
             msg += "kill        Kill current task\n"
             msg += "list        Display all tasks\n"
+            msg += "flush       Flush tasks (delete all tasks)\n"
             msg += "exit        Exit this client\n"
 
             dataToStdout(msg)


### PR DESCRIPTION
Stop & kill were straightforward. For list:
- I removed the permission check (admin_id)
- I also list the task status

I kept it backwards compatible: you can still call list with the admin taskid and get the simple list back.