### PR TITLE
enhance recognition of "baiduyun" in waf/baidu.py

### DIFF
--- a/waf/baidu.py
+++ b/waf/baidu.py
@@ -17,6 +17,7 @@ def detect(get_page):
     for vector in WAF_ATTACK_VECTORS:
         page, headers, code = get_page(get=vector)
         retval = re.search(r"fhl", headers.get("X-Server", ""), re.I) is not None
+        retval |= re.search(r"yunjiasu-nginx", headers.get("server"), re.I) is not None
         if retval:
             break
 


### PR DESCRIPTION
The former recognition is not that accurate because "Yunjiasu Web Application Firewall (Baidu)" didn't have a specific trait back then.
But now it has the "server: yunjiasu-nginx" headers which makes it more easily to recongnize.
And I tested serval sites using this WAF, the old baidu.py doesn't work besides with "__cfduid" in cookie it was alwasy mistoken for Cloudflare,by adding new new regex pattern in "waf/baidu.py" the problem is now solved.