### PR TITLE
Addition to IBM DB2 SQL Error Identification

### DIFF
--- a/xml/errors.xml
+++ b/xml/errors.xml
@@ -54,6 +54,8 @@
         <error regexp="CLI Driver.*DB2"/>
         <error regexp="DB2 SQL error"/>
         <error regexp="\bdb2_\w+\("/>
+        <error regexp="SQLSTATE"/>
+        <error regexp="SQLCODE"/>
     </dbms>
 
     <!-- Informix -->

--- a/xml/errors.xml
+++ b/xml/errors.xml
@@ -54,8 +54,7 @@
         <error regexp="CLI Driver.*DB2"/>
         <error regexp="DB2 SQL error"/>
         <error regexp="\bdb2_\w+\("/>
-        <error regexp="SQLSTATE"/>
-        <error regexp="SQLCODE"/>
+        <error regexp="(?i)SQLSTATE.* SQLCODE.*"/>
     </dbms>
 
     <!-- Informix -->


### PR DESCRIPTION
Additional error regex value to look for "SQLSTATE" and "SQLCODE". In the research I have done, the presence of both strings in an error message is specific to IBM DB2 databases. That being said you guys would know better than I would if this would be prone to lots of false positives or not...

Documentation of the codes here:

https://www-304.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/com.ibm.db2z10.doc.codes/src/tpc/db2z_sqlstatevalues.dita

http://www-01.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/com.ibm.db2z10.doc.codes/src/tpc/db2z_sqlcodes.dita

