### PR TITLE
Avoid NULL bytes when writing to file

### DIFF
--- a/lib/core/agent.py
+++ b/lib/core/agent.py
@@ -746,6 +746,10 @@ class Agent(object):
         if intoRegExp:
             intoRegExp = intoRegExp.group(1)
             query = query[:query.index(intoRegExp)]
+            # The position is irrelevant when writing into a file,
+            # so bump the payload to the first position to avoid
+            # NULL bytes written into the file
+            position = 0
 
         for element in xrange(0, count):
             if element > 0:


### PR DESCRIPTION
Hello team,

At the moment MySQL UNION based file writes (--write-file) place the payload according to the injection position decided during the analysis phase. This can be any position in the list of NULLs so there's a chance NULLs will be inserted into the file, and when these bytes come before the payload it can corrupt the file signature. sqlmap warns users that this may happen, and this is not a problem for a PHP web shell, but it might be undesirable in other situations.

This tiny change bumps the payload position to the first when a UNION query with INTO (DUMP|FILE) is taking place. I was not able to see a negative side effect of always pushing the payload to the first position in file writes, but I could have missed something. Also there might be a better place to insert this change, or it may not be a desired change in behavior at all.

Finally this could be taken one step further, where the payload's bytes are distributed among the positions available to completely eliminate the possibility of inserting junk characters anywhere, but this is probably a good place to start.

Please review and decide what's the best course of action.

Thanks.