### PR TITLE
Add initial .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,4 @@ root = true
 
 [*.py]
 indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+root = true
+
+[*.py]
+indent_style = space


### PR DESCRIPTION
Given [it's mentioned in the FAQ page](https://github.com/sqlmapproject/sqlmap/wiki/FAQ#can-i-contribute-occasionally-to-the-development):

> Avoid tabbing, use four blank spaces instead.

And that it's not currently being used within the project, I thought to add an initial .editorconfig file defining just the spacing policy for `.py` files. This should let (EditorConfig compliant) IDEs used by contributors do the right thing when it comes to spacing.

I didn't add anything else as this is my first commit and look at the project as a whole, so I'd leave this to the core project maintainers ;)