### PR TITLE
Converting a command to lowercase breaks a case-sensitive URL

### DIFF
--- a/lib/utils/api.py
+++ b/lib/utils/api.py
@@ -722,7 +722,7 @@ def client(host=RESTAPI_DEFAULT_ADDRESS, port=RESTAPI_DEFAULT_PORT):
 
     while True:
         try:
-            command = raw_input("api%s> " % (" (%s)" % taskid if taskid else "")).strip().lower()
+            command = raw_input("api%s> " % (" (%s)" % taskid if taskid else "")).strip()
         except (EOFError, KeyboardInterrupt):
             print
             break


### PR DESCRIPTION
To reproduce the bug:

1. Start the server: ./sqlmapapi.py -s

2. Start the client: ./sqlmapapi.py -c

3. Add a new task with a case-sensitive URL: new -u "http://vbox.lc/bWAPP/sqli_4.php?title=iron+man&action=search"

4. Check the log: 
   ...
   "message": "testing connection to the target URL"
   ...
   "message": "page not found (404)"
   ...
   "message": "HTTP error codes detected during run:\n404 (Not Found) - 1 times"

5. Check that sqlmap.py correcty work with same parameters: ./sqlmap.py -u "http://vbox.lc/bWAPP/sqli_4.php?title=iron+man&action=search"
   [INFO] testing connection to the target URL
   [INFO] checking if the target is protected by some kind of WAF/IPS/IDS