### PR TITLE
baidu search engine support

### DIFF
--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -94,6 +94,9 @@ DUCKDUCKGO_REGEX = r'"u":"([^"]+)'
 # Regular expression used for extracting results from Disconnect Search
 DISCONNECT_SEARCH_REGEX = r'<p class="url wrapword">([^<]+)</p>'
 
+# Regular expression used for extracting results from Baidu Search
+BAIDU_SEARCH_REGEX = r'<a\s+[\w\W]+?\s+href\s*=\s*"(.+)?"\s+target\s*=\s*"_blank"\s*>'
+
 # Dummy user agent for search (if default one returns different results)
 DUMMY_SEARCH_USER_AGENT = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:40.0) Gecko/20100101 Firefox/40.0"
 


### PR DESCRIPTION
add baidu(www.baidu.com) search engine support.  

In china, google can't be accessed directly if you don't have a proxy or VPN. Original code will make sqlmap to exit if google can't be accessed or connected. I changed the action, and make the code to use google search only when google is reachable.   The added code of baidu search support will do an extra "finding real url". Because in result of baidu, we can't see the real url, we have to access the result one by one to get the real URL. At last, I removed similar/duplicate URLs from retVal because baidu's results often include some similar or duplicate ones.  
