### PR TITLE
Fix the logic used for --param-exclude

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -470,7 +470,7 @@ def start():
                             infoMsg = "skipping %s parameter '%s'" % (paramType, parameter)
                             logger.info(infoMsg)
 
-                        elif re.search(conf.paramExclude or "", parameter, re.I) or kb.postHint and re.search(conf.paramExclude or "", parameter.split(' ')[-1], re.I):
+                        elif conf.paramExclude and (re.search(conf.paramExclude, parameter, re.I) or kb.postHint and re.search(conf.paramExclude, parameter.split(' ')[-1], re.I)):
                             testSqlInj = False
 
                             infoMsg = "skipping %s parameter '%s'" % (paramType, parameter)


### PR DESCRIPTION
The current logic will skip all existing parameters if no param-exclude is defined.
This breaks previous behaviour, makes it harder to use the tool and is quite confusing.

The new logic will always check the parameter is set before running any other checks instead of shortcircuit an empoty(always true) regexp.