### PR TITLE
Prevent sqlmap from hanging on long responses without newlines

### DIFF
--- a/lib/controller/checks.py
+++ b/lib/controller/checks.py
@@ -1005,11 +1005,10 @@ def heuristicCheckSqlInjection(place, parameter):
         logger.info(infoMsg)
 
     for match in re.finditer(FI_ERROR_REGEX, page or ""):
-        if randStr1.lower() in match.group(0).lower():
-            infoMsg = "heuristic (FI) test shows that %s parameter " % paramType
-            infoMsg += "'%s' might be vulnerable to file inclusion attacks" % parameter
-            logger.info(infoMsg)
-            break
+        infoMsg = "heuristic (FI) test shows that %s parameter " % paramType
+        infoMsg += "'%s' might be vulnerable to file inclusion attacks" % parameter
+        logger.info(infoMsg)
+        break
 
     kb.heuristicMode = False
 

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -587,7 +587,7 @@ BANNER = re.sub(r"\[.\]", lambda _: "[\033[01;41m%s\033[01;49m]" % random.sample
 DUMMY_NON_SQLI_CHECK_APPENDIX = "<'\">"
 
 # Regular expression used for recognition of file inclusion errors
-FI_ERROR_REGEX = "(?i)[^\n]*(no such file|failed (to )?open)[^\n]*"
+FI_ERROR_REGEX = "(?i)(no such file|failed (to )?open)"
 
 # Length of prefix and suffix used in non-SQLI heuristic checks
 NON_SQLI_CHECK_PREFIX_SUFFIX_LENGTH = 6


### PR DESCRIPTION
When sqlmap is used to test a URL that returns a long body that contains no '\n' characters, it will hang for an inordinately long time (minutes or more) while attempting to test the file inclusion error heuristic. This is because the current default FI_ERROR_REGEX exhibits explosive runtime growth on strings with no '\n' characters.

This patch changes the default FI_ERROR_REGEX to perform efficiently on these strings while still identifying the same matches.

Below is a demonstration of the performance implications. Responses longer than 60000 bytes will cause exponentially longer hangs.

> [jmage@Oblivion sqlmap]$ time python2 -c "import re, lib.core.settings; re.findall(lib.core.settings.FI_ERROR_REGEX,'x'*60000)"
> 
> real    1m22.890s
> user    1m22.853s
> sys     0m0.007s
> [jmage@Oblivion sqlmap]$ git checkout regex_speed
> Switched to branch 'regex_speed'
> Your branch is up-to-date with 'origin/regex_speed'.
> [jmage@Oblivion sqlmap]$ time python2 -c "import re, lib.core.settings; re.findall(lib.core.settings.FI_ERROR_REGEX,'x'*60000)"
> 
> real    0m0.040s
> user    0m0.033s
> sys     0m0.003s
> [jmage@Oblivion sqlmap]$

The location where sqlmap hangs with the current regex is: https://github.com/sqlmapproject/sqlmap/blob/55272f7a3b5a771b0630b7c8c4a61bab7ba8f27f/lib/controller/checks.py#L1007