### PR TITLE
REST API: command line processing on the server side

### DIFF
--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -38,7 +38,7 @@ from lib.core.shell import clearHistory
 from lib.core.shell import loadHistory
 from lib.core.shell import saveHistory
 
-def cmdLineParser(argv=None):
+def cmdLineParser(argv=None, interactive=True):
     """
     This function parses the command line parameters and arguments
     """
@@ -973,7 +973,7 @@ def cmdLineParser(argv=None):
 
     except SystemExit:
         # Protection against Windows dummy double clicking
-        if IS_WIN:
+        if IS_WIN and interactive:
             dataToStdout("\nPress Enter to continue...")
             raw_input()
         raise


### PR DESCRIPTION
We are writing a sqlmap API client for verifying SQLi exploits. The exploits come to us in the form of sqlmap command line options. For example:
`-u 'http://server/query?sort=tag' -p sort --dbms=mysql --level=5 --technique=T --time-sec=1 -b --answers="redirect to=N,extending provided risk=N,keep testing the others=N"`

Currently, the API's _start_ function expects a JSON. This is trivial to achieve for the sample API client (sqlmapapi.py -c) since it shares the codebase with sqlmap.py and has access to _cmdLineParser()_, but for our application, it would be very non-trivial.

I added support for parsing the command line options on the API server side, so the API client can stay completely ignorant of the internal sqlmap option representation and processing.