### PR TITLE
Fix proxyFile regex to properly match an address with a -

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -2324,7 +2324,7 @@ def _setProxyList():
         return
 
     conf.proxyList = []
-    for match in re.finditer(r"(?i)((http[^:]*|socks[^:]*)://)?([\w.]+):(\d+)", readCachedFileContent(conf.proxyFile)):
+    for match in re.finditer(r"(?i)((http[^:]*|socks[^:]*)://)?([\w\-.]+):(\d+)", readCachedFileContent(conf.proxyFile)):
         _, type_, address, port = match.groups()
         conf.proxyList.append("%s://%s:%s" % (type_ or "http", address, port))
 


### PR DESCRIPTION
Hi!

If you have a proxy file and have some hosts with - (and it's a valid char for a domain) the regex that matches the type_, address and port doesn't works properly.

Just added the - on the regex and every thing works fine!

```
$ python test.py
Testing string: foo.bar:80 fo-o.bar:80 foo-bar.foo.bar:80 foo-bar.fo-o.bar:80

Results for old regex:
http://foo.bar:80
http://o.bar:80
http://bar.foo.bar:80
http://o.bar:80


Results for new regex:
http://foo.bar:80
http://fo-o.bar:80
http://foo-bar.foo.bar:80
http://foo-bar.fo-o.bar:80
```
