### PR TITLE
IP address regex updated to not provide a false positive

### DIFF
--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -109,7 +109,7 @@ DUMMY_SEARCH_USER_AGENT = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Geck
 TEXT_TAG_REGEX = r"(?si)<(abbr|acronym|b|blockquote|br|center|cite|code|dt|em|font|h\d|i|li|p|pre|q|strong|sub|sup|td|th|title|tt|u)(?!\w).*?>(?P<result>[^<]+)"
 
 # Regular expression used for recognition of IP addresses
-IP_ADDRESS_REGEX = r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b"
+IP_ADDRESS_REGEX = r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
 
 # Regular expression used for recognition of generic "your ip has been blocked" messages
 BLOCKED_IP_REGEX = r"(?i)(\A|\b)ip\b.*\b(banned|blocked|block list|firewall)"


### PR DESCRIPTION
Updated the IP address regex from `\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b` to `^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$` the latter will not provide a false positive. The old style regex would match anything as long as it's in the format `0.0.0.0` including `999.999.999.999` see [here](https://regex101.com/r/hcQKT9/5) for examples. The newer style regex will not match anything over `255.255.255.255` see [here](https://regex101.com/r/hcQKT9/3) for examples of the new regex.

Basic examples:

```
>>> import re
>>> IP_REGEXS = [r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"]
>>> IP_ADDRS = ["127.0.0.1", "255.255.255.255", "999.999.999.999", "257.12.34.543", "12.09.87.24"]  # Only the first two should match (127.0.0.1, 255.255.255.255)
>>> for item in IP_REGEXS:
	for ip in IP_ADDRS:
		if re.match(item, ip):
			print("{} matched {}".format(item, ip))
		else:
			print("{} did not match {}".format(item, ip))

			
\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b matched 127.0.0.1
\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b matched 255.255.255.255
\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b matched 999.999.999.999
\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b matched 257.12.34.543
\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b matched 12.09.87.24
^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ matched 127.0.0.1
^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ matched 255.255.255.255
^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ did not match 999.999.999.999
^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ did not match 257.12.34.543
^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ did not match 12.09.87.24  # Did not match because ..09.. is not a valid IP address, valid would just be 9
>>> 
```