### PR TITLE
Fix misuse of flags in re.sub() calls

### DIFF
--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -310,8 +310,8 @@ class Connect(object):
 
             elif target:
                 if conf.forceSSL and urlparse.urlparse(url).scheme != "https":
-                    url = re.sub("\Ahttp:", "https:", url, re.I)
-                    url = re.sub(":80/", ":443/", url, re.I)
+                    url = re.compile("\Ahttp:", re.I).sub("https:", url)
+                    url = re.sub(":80/", ":443/", url)
 
                 if PLACE.GET in conf.parameters and not get:
                     get = conf.parameters[PLACE.GET]

--- a/lib/techniques/union/use.py
+++ b/lib/techniques/union/use.py
@@ -226,7 +226,7 @@ def unionUse(expression, unpack=True, dump=False):
 
     if expressionFieldsList and len(expressionFieldsList) > 1 and "ORDER BY" in expression.upper():
         # Removed ORDER BY clause because UNION does not play well with it
-        expression = re.sub("\s*ORDER BY\s+[\w,]+", "", expression, re.I)
+        expression = re.compile("\s*ORDER BY\s+[\w,]+", re.I).sub("", expression)
         debugMsg = "stripping ORDER BY clause from statement because "
         debugMsg += "it does not play well with UNION query SQL injection"
         singleTimeDebugMessage(debugMsg)


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.

Found using [pydiatra](https://github.com/jwilk/pydiatra).