### PR TITLE
append %A0 to the blanks set of tamper/space2mysqlblank

### DIFF
--- a/tamper/space2mysqlblank.py
+++ b/tamper/space2mysqlblank.py
@@ -42,7 +42,8 @@ def tamper(payload, **kwargs):
     #   FF      0C      new page
     #   CR      0D      carriage return
     #   VT      0B      vertical TAB        (MySQL and Microsoft SQL Server only)
-    blanks = ('%09', '%0A', '%0C', '%0D', '%0B')
+    #           A0      non-breaking space
+    blanks = ('%09', '%0A', '%0C', '%0D', '%0B', '%A0')
     retVal = payload
 
     if payload:


### PR DESCRIPTION
In mysql, '%A0'(non-breaking space) is the same with '%09', '%0A', '%0C', '%0D', '%0B', can be use to replace with space.