### PR TITLE
`response code=404` handle modify and `https with -r` handle modify

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -331,7 +331,12 @@ def _feedTargetsDict(reqFile, addedTargetUrls):
                 elif not scheme and port == "443":
                     scheme = "https"
 
-                if conf.forceSSL:
+                hostPattern=host.replace(".","\.")
+                if (conf.forceSSL or re.search(r"host:[^\n\r]*%s:%s[\s\S]*referer:[^\n\r]*https://%s:%s.*" %
+                                              (hostPattern, port, hostPattern, port), request, re.I)
+                or (port != 80
+                    and re.search(r"host:[^\n\r]*%s:%s[\s\S]*referer:[^\n\r]*https://.*cdn.*" %
+                                  (hostPattern, port), request, re.I))):
                     scheme = "https"
                     port = port or "443"
 

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -334,7 +334,7 @@ def _feedTargetsDict(reqFile, addedTargetUrls):
                 hostPattern=host.replace(".","\.")
                 if (conf.forceSSL or re.search(r"host:[^\n\r]*%s:%s[\s\S]*referer:[^\n\r]*https://%s:%s.*" %
                                               (hostPattern, port, hostPattern, port), request, re.I)
-                or (port != 80
+                or (port != "80"
                     and re.search(r"host:[^\n\r]*%s:%s[\s\S]*referer:[^\n\r]*https://.*cdn.*" %
                                   (hostPattern, port), request, re.I))):
                     scheme = "https"

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """
 Copyright (c) 2006-2017 sqlmap developers (http://sqlmap.org/)
@@ -596,8 +597,11 @@ class Connect(object):
                 raise SqlmapConnectionException(errMsg)
             elif ex.code == httplib.NOT_FOUND:
                 if raise404:
-                    errMsg = "page not found (%d)" % code
-                    raise SqlmapConnectionException(errMsg)
+                    if re.search(r"(not found)|(404)|(页面不存在)",page,re.I):
+                        # If both code=404 and page content has 404's features,then url is 404 url
+                        # If not as upon,only code=404 can not determin the url is 404 url,because waf always return 404 code
+                        errMsg = "page not found (%d)" % code
+                        raise SqlmapConnectionException(errMsg)
                 else:
                     debugMsg = "page not found (%d)" % code
                     singleTimeLogMessage(debugMsg, logging.DEBUG)

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -597,7 +597,7 @@ class Connect(object):
                 raise SqlmapConnectionException(errMsg)
             elif ex.code == httplib.NOT_FOUND:
                 if raise404:
-                    if re.search(r"(not found)|(404)|(页面不存在)",page,re.I):
+                    if re.search(r"(not found)|(404)|(页面不存在)|(未找到页面)",page,re.I):
                         # If both code=404 and page content has 404's features,then url is 404 url
                         # If not as upon,only code=404 can not determin the url is 404 url,because waf always return 404 code
                         errMsg = "page not found (%d)" % code


### PR DESCRIPTION
detail:
<a href ="http://3xp10it.cc/web/2017/08/20/sqlmap%E5%AF%B9%E7%8A%B6%E6%80%81%E7%A0%81404%E5%A4%84%E7%90%86%E7%9A%84bug/">sqlmap 404 handle bug</a>

When sqlmap got 404 code from the server,sqlmap will raise a exit exception and will not scan the url's sqli anymore,but some 404 code may not be a real 404 code,`dvwa` is an example,and some waf may return 404 http response code,but the body content in the page of the url is not `404` type content,so I add a handle to recgnize whether the code 404 is a real 404 or not,if the 404 is not a real 404,sqlmap will not raise the exception and go on with latter tests.

