### PR TITLE
add strim for path variable

### DIFF
--- a/lib/utils/brute.py
+++ b/lib/utils/brute.py
@@ -81,6 +81,7 @@ def tableExists(tableFile, regex=None):
     if choice == '2':
         message = "what's the custom common tables file location?\n"
         tableFile = readInput(message) or tableFile
+        tableFile = tableFile.strim('"')
 
     infoMsg = "checking table existence using items from '%s'" % tableFile
     logger.info(infoMsg)


### PR DESCRIPTION
An error occurred when I used the feature "custom common column existence check".
I found it's caused by the double quotation marks which was added by "Copy as path"(a feature in Windows) automatically.
(e.g: "D:\dist\dict1.txt")
I think it's not a good idea that let user delete the double quotes manually.