### PR TITLE
Fixed json data non-string values passed to a target as strings

### DIFF
--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -142,8 +142,8 @@ def _setRequestParams():
                     conf.data = getattr(conf.data, UNENCODED_ORIGINAL_VALUE, conf.data)
                     conf.data = conf.data.replace(kb.customInjectionMark, ASTERISK_MARKER)
                     conf.data = re.sub(r'("(?P<name>[^"]+)"\s*:\s*"[^"]*)"', functools.partial(process, repl=r'\g<1>%s"' % kb.customInjectionMark), conf.data)
-                    conf.data = re.sub(r'("(?P<name>[^"]+)"\s*:\s*)(-?\d[\d\.]*)\b', functools.partial(process, repl=r'\g<1>"\g<3>%s"' % kb.customInjectionMark), conf.data)
-                    conf.data = re.sub(r'("(?P<name>[^"]+)"\s*:\s*)((true|false|null))\b', functools.partial(process, repl=r'\g<1>"\g<3>%s"' % kb.customInjectionMark), conf.data)
+                    conf.data = re.sub(r'("(?P<name>[^"]+)"\s*:\s*)(-?\d[\d\.]*)\b', functools.partial(process, repl=r'\g<1>\g<3>%s' % kb.customInjectionMark), conf.data)
+                    conf.data = re.sub(r'("(?P<name>[^"]+)"\s*:\s*)((true|false|null))\b', functools.partial(process, repl=r'\g<1>\g<3>%s' % kb.customInjectionMark), conf.data)
                     match = re.search(r'(?P<name>[^"]+)"\s*:\s*\[([^\]]+)\]', conf.data)
                     if match and not (conf.testParameter and match.group("name") not in conf.testParameter):
                         _ = match.group(2)


### PR DESCRIPTION
When you send JSON data with POST request consisting numeric or boolean values in original JSON body, all these values are transformed to string representations and send out to a target as strings. All requests with transformed JSON data are rejected by target server due to JSON parse errors. I've changed replacing of original values with strings alternatives for boolean and numeric values. Probably, I do not know the original idea of that logic and some additional changes are required, but right now all requests with JSON body consisting numeric and boolean values fail and tests are not possible, with that fix requests are sent correctly and tests work, please, review.