### PR TITLE
fix a deprecation warning coming from lib.core.common

### DIFF
--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -32,6 +32,9 @@ import urllib
 import urllib2
 import urlparse
 import unicodedata
+import warnings
+
+warnings.filterwarnings(action="ignore", category=DeprecationWarning)
 
 from ConfigParser import DEFAULTSECT
 from ConfigParser import RawConfigParser


### PR DESCRIPTION
The warning looks like this when calling the sqlmap API:

```
/home/baal/bin/python/sqlmap/lib/core/common.py:4430: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
  if getattr(ex, "message", None):
```