### PR TITLE
Batch file to run on windows commandline

### DIFF
--- a/sqlmap.bat
+++ b/sqlmap.bat
@@ -1,0 +1,1 @@
+python %~dp0\sqlmap.py %1 %2 %3 %4 %5 %6 %7 %8 %9


### PR DESCRIPTION
Batch file to runnable on command prompt with **sqlmap** command after setting up Windows environment variable path to sqlmap and python27 directory.