### PR TITLE
Commit to make CLI option to disable counting

### DIFF
--- a/lib/techniques/error/use.py
+++ b/lib/techniques/error/use.py
@@ -383,7 +383,7 @@ def errorUse(expression, dump=False):
                 if threadData.shared.showEta:
                     threadData.shared.progress = ProgressBar(maxValue=(stopLimit - startLimit))
 
-                if kb.dumpTable and (len(expressionFieldsList) < (stopLimit - startLimit) > CHECK_ZERO_COLUMNS_THRESHOLD):
+                if kb.dumpTable and (kb.count) and (len(expressionFieldsList) < (stopLimit - startLimit) > CHECK_ZERO_COLUMNS_THRESHOLD):
                     for field in expressionFieldsList:
                         if _oneShotErrorUse("SELECT COUNT(%s) FROM %s" % (field, kb.dumpTable)) == '0':
                             emptyFields.append(field)


### PR DESCRIPTION
I was pentesting , when i found lots of null entries in a table

examining it showed that sqlmap ignores when count returns zero (don't know why)

however commenting out the code retrieved data

so going to add this here as command line option (i was wondered that there were no such option)