### PR TITLE
Made referer=None when  --check-tor

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -2359,7 +2359,7 @@ def _checkTor():
     logger.info(infoMsg)
 
     try:
-        page, _, _ = Request.getPage(url="https://check.torproject.org/", raise404=False)
+        page, _, _ = Request.getPage(url="https://check.torproject.org/", referer=None, raise404=False)
     except SqlmapConnectionException:
         page = None
 


### PR DESCRIPTION
SQLMap was sending the target URL to check.torproject.org in the referrer for no apparent reason.
This would put check.torproject.org in a position to learn about what URLs were being used by sqlmap users when they use the --check-tor option and also who is doing it in the event --tor wasn't working properly.