### PR TITLE
errors.xml: detect mysqli_*() errors.

### DIFF
--- a/xml/errors.xml
+++ b/xml/errors.xml
@@ -4,7 +4,7 @@
     <!-- MySQL -->
     <dbms value="MySQL">
         <error regexp="SQL syntax.*?MySQL"/>
-        <error regexp="Warning.*?mysql_"/>
+        <error regexp="Warning.*?mysqli?_"/>
         <error regexp="MySqlException \(0x"/>
         <error regexp="MySQLSyntaxErrorException"/>
         <error regexp="valid MySQL result"/>


### PR DESCRIPTION
MySQL injection error message often happen with
mysqli_*() functions nowadays.
POC: https://duckduckgo.com/?q=%22warning..mysqli