### PR TITLE
Fix incompatible errMsg for tor and osPwn args

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -2306,7 +2306,7 @@ def _basicOptionValidation():
         errMsg = "option '--not-string' is incompatible with switch '--null-connection'"
         raise SqlmapSyntaxException(errMsg)
 
-    if conf.notString and conf.nullConnection:
+    if conf.tor and conf.osPwn:
         errMsg = "option '--tor' is incompatible with switch '--os-pwn'"
         raise SqlmapSyntaxException(errMsg)
 


### PR DESCRIPTION
The condition to check if the --tor and --os-pwn is used at the same time is wrong.