### PR TITLE
Added the possibility to modify the response

### DIFF
--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -19,6 +19,7 @@ import traceback
 import urllib
 import urllib2
 import urlparse
+from plugins.response import response_tamper
 
 try:
     import websocket
@@ -1320,6 +1321,10 @@ class Connect(object):
         if message:
             kb.permissionFlag = True
             singleTimeWarnMessage("potential permission problems detected ('%s')" % message)
+
+        page = response_tamper.tamper_page(page)
+        headers = response_tamper.tamper_headers(headers)
+        code = response_tamper.tamper_code(code)
 
         if content or response:
             return page, headers, code

--- a/plugins/response/__init__.py
+++ b/plugins/response/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2019 sqlmap developers (http://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+pass

--- a/plugins/response/response_tamper.py
+++ b/plugins/response/response_tamper.py
@@ -1,0 +1,9 @@
+def tamper_page(page):
+    return page
+
+def tamper_headers(headers):
+    return headers
+    
+def tamper_code(code):
+    return code
+    


### PR DESCRIPTION
I added a hook to programmatically modify the response page, headers and code before interpreting the reponse. You can change the behavior by playing with the file plugins/response/response_tamper.py
This can be used when sqlmap can't handle when a small detail in the page changes in response to a payload.
For example, if the only difference is the sorting order of a table
ex:
id, name, status
1, test, ok
2, test2, notOK

VS
id, name, status
2, tes2, notOK
1, test, ok

In this case, you could add some python code to completly change the result in the page to "TRUE" if case 1 and "FALSE" in case 2.