### PR TITLE
IBM Webseal

### DIFF
--- a/waf/ibm_webseal.py
+++ b/waf/ibm_webseal.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2019 sqlmap developers (http://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+import re
+
+from lib.core.enums import HTTP_HEADER
+from lib.core.settings import WAF_ATTACK_VECTORS
+
+__product__ = "IBM Security Access Manager for Web WebSEAL."
+
+def detect(get_page):
+    retval = False
+
+    for vector in WAF_ATTACK_VECTORS:
+        _, headers, _ = get_page(get=vector)
+        retval = re.search(r"WebSEAL/9.0.5.0", headers.get(HTTP_HEADER.SERVER, ""), re.I) is not None
+	retval |= "The Access Manager WebSEAL server received an invalid HTTP request." in (page or "") is not None
+        if retval:
+            break
+
+    return retval


### PR DESCRIPTION
**HTTP Request**
```
GET /?search=%3Cscript%3Ealert(/xss/)%3C/script%3E HTTP/1.1
Host: example.com
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:65.0) Gecko/20100101 Firefox/65.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: close
```
**HTTP Response**
```
HTTP/1.1 400 Bad Request
content-length: 1382
content-type: text/html
date: Sat, 09 Feb 2019 11:17:46 GMT
p3p: CP="NON CUR OTPi OUR NOR UNI"
server: WebSEAL/9.0.5.0
cache-control: no-store
strict-transport-security: 
pragma: no-cache
```
![image](https://www.ibm.com/support/knowledgecenter/kk/SSPREK_7.0.0/com.ibm.isam.doc_80/ameb_webseal_guide/graphics/webseal.gif)