### PR TITLE
Support for chunked requests

### DIFF
--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -98,7 +98,7 @@ from lib.core.exception import SqlmapUserQuitException
 from lib.core.exception import SqlmapValueException
 from lib.core.log import LOGGER_HANDLER
 from lib.core.optiondict import optDict
-from lib.core.settings import BANNER
+from lib.core.settings import BANNER, CHUNKED_KEYWORDS
 from lib.core.settings import BOLD_PATTERNS
 from lib.core.settings import BOUNDED_INJECTION_MARKER
 from lib.core.settings import BRUTE_DOC_ROOT_PREFIXES
@@ -4919,7 +4919,7 @@ def generateChunkDdata(data):
     """
     dl = len(data)
     ret = ""
-    keywords = CHUNK_KEYWORDS
+    keywords = CHUNKED_KEYWORDS
     index = 0
     while index < dl:
         chunk_size = random.randint(1, 9)

--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -4895,3 +4895,50 @@ def firstNotNone(*args):
             break
 
     return retVal
+
+def generateChunkDdata(data):
+    """
+    Convert post data to chunked format data. If the keyword is in a block, the keyword will be cut.
+
+    >>> generateChunkDdata('select 1,2,3,4 from admin')
+    4;AZdYz
+    sele
+    2;fJS4D
+    ct
+    5;qbCOT
+    1,2,
+    7;KItpi
+    3,4 fro
+    2;pFu1R
+    m 
+    5;uRoYZ
+    admin
+    0
+
+
+    """
+    dl = len(data)
+    ret = ""
+    keywords = CHUNK_KEYWORDS
+    index = 0
+    while index < dl:
+        chunk_size = random.randint(1, 9)
+        if index + chunk_size >= dl:
+            chunk_size = dl - index
+        salt = ''.join(random.sample(string.ascii_letters + string.digits, 5))
+        while 1:
+            tmp_chunk = data[index:index + chunk_size]
+            tmp_bool = True
+            for k in keywords:
+                if k in tmp_chunk:
+                    chunk_size -= 1
+                    tmp_bool = False
+                    break
+            if tmp_bool:
+                break
+        index += chunk_size
+        ret += "%s;%s\r\n" % (hex(chunk_size)[2:], salt)
+        ret += "%s\r\n" % tmp_chunk
+
+    ret += "0\r\n\r\n"
+    return ret

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -7,6 +7,7 @@ See the file 'LICENSE' for copying permission
 
 import cookielib
 import glob
+import httplib
 import inspect
 import logging
 import os
@@ -139,6 +140,7 @@ from lib.request.basic import checkCharEncoding
 from lib.request.connect import Connect as Request
 from lib.request.dns import DNSServer
 from lib.request.basicauthhandler import SmartHTTPBasicAuthHandler
+from lib.request.httphandler import HTTPHandler
 from lib.request.httpshandler import HTTPSHandler
 from lib.request.pkihandler import HTTPSPKIAuthHandler
 from lib.request.rangehandler import HTTPRangeHandler
@@ -156,6 +158,7 @@ from thirdparty.socks import socks
 from xml.etree.ElementTree import ElementTree
 
 authHandler = urllib2.BaseHandler()
+httpHandler = HTTPHandler()
 httpsHandler = HTTPSHandler()
 keepAliveHandler = keepalive.HTTPHandler()
 proxyHandler = urllib2.ProxyHandler()
@@ -1106,7 +1109,7 @@ def _setHTTPHandlers():
     debugMsg = "creating HTTP requests opener object"
     logger.debug(debugMsg)
 
-    handlers = filter(None, [multipartPostHandler, proxyHandler if proxyHandler.proxies else None, authHandler, redirectHandler, rangeHandler, httpsHandler])
+    handlers = filter(None, [multipartPostHandler, proxyHandler if proxyHandler.proxies else None, authHandler, redirectHandler, rangeHandler, httpHandler, httpsHandler])
 
     if not conf.dropSetCookie:
         if not conf.loadCookies:
@@ -2602,6 +2605,13 @@ def initOptions(inputOptions=AttribDict(), overrideOptions=False):
     _setKnowledgeBaseAttributes()
     _mergeOptions(inputOptions, overrideOptions)
 
+def _setHttpChunked():
+    if conf.chunk:
+        def hook(self, a, b):
+            pass
+
+        httplib.HTTPConnection._set_content_length = hook
+
 def init():
     """
     Set attributes into both configuration and knowledge base singletons
@@ -2627,6 +2637,7 @@ def init():
     _listTamperingFunctions()
     _setTamperingFunctions()
     _setPreprocessFunctions()
+    _setHttpChunked()
     _setWafFunctions()
     _setTrafficOutputFP()
     _setupHTTPCollector()

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -2606,11 +2606,13 @@ def initOptions(inputOptions=AttribDict(), overrideOptions=False):
     _mergeOptions(inputOptions, overrideOptions)
 
 def _setHttpChunked():
+    conf.chunk = conf.chunk and conf.data
     if conf.chunk:
         def hook(self, a, b):
             pass
 
         httplib.HTTPConnection._set_content_length = hook
+
 
 def init():
     """

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -794,6 +794,9 @@ KB_CHARS_BOUNDARY_CHAR = 'q'
 # Letters of lower frequency used in kb.chars
 KB_CHARS_LOW_FREQUENCY_ALPHABET = "zqxjkvbp"
 
+# Keywords that need to be cut in the chunked
+CHUNKED_KEYWORDS = ['select', 'update', 'insert', 'from', 'load_file', 'sysdatabases', 'msysaccessobjects', 'msysqueries', 'sysmodules', 'information_schema']
+
 # CSS style used in HTML dump format
 HTML_DUMP_CSS_STYLE = """<style>
 table{

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -795,7 +795,7 @@ KB_CHARS_BOUNDARY_CHAR = 'q'
 KB_CHARS_LOW_FREQUENCY_ALPHABET = "zqxjkvbp"
 
 # Keywords that need to be cut in the chunked
-CHUNKED_KEYWORDS = ['select', 'update', 'insert', 'from', 'load_file', 'sysdatabases', 'msysaccessobjects', 'msysqueries', 'sysmodules', 'information_schema']
+CHUNKED_KEYWORDS = ['select', 'update', 'insert', 'from', 'load_file', 'sysdatabases', 'msysaccessobjects', 'msysqueries', 'sysmodules', 'information_schema', 'union']
 
 # CSS style used in HTML dump format
 HTML_DUMP_CSS_STYLE = """<style>

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -220,6 +220,8 @@ def cmdLineParser(argv=None):
 
         request.add_option("--eval", dest="evalCode",
                            help="Evaluate provided Python code before the request (e.g. \"import hashlib;id2=hashlib.md5(id).hexdigest()\")")
+        
+        request.add_option("--chunk", dest="chunk", action="store_true", help="all requests will be added headers with 'Transfer-Encoding: Chunked' and sent by transcoding")
 
         # Optimization options
         optimization = OptionGroup(parser, "Optimization", "These options can be used to optimize the performance of sqlmap")

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -277,6 +277,7 @@ class Connect(object):
         if multipart:
             post = multipart
         if chunked:
+            post = urllib.unquote(post)
             post = generateChunkDdata(post)
 
         websocket_ = url.lower().startswith("ws")
@@ -471,12 +472,10 @@ class Connect(object):
                 requestMsg += "\r\n%s" % requestHeaders
 
                 if post is not None:
-                    if chunked:
-                        requestMsg += getUnicode(post)
-                    else:
-                        requestMsg += "\r\n\r\n%s" % getUnicode(post)
+                    requestMsg += "\r\n\r\n%s" % getUnicode(post)
 
-                requestMsg += "\r\n"
+                if not chunked:
+                    requestMsg += "\r\n"
 
                 if not multipart:
                     threadData.lastRequestMsg = requestMsg

--- a/lib/request/httphandler.py
+++ b/lib/request/httphandler.py
@@ -1,14 +1,19 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# @Time    : 2019/3/16 2:48 PM
-# @Author  : w8ay
-# @File    : httphandler.py
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2019 sqlmap developers (http://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
 import urllib2
 import httplib
 from lib.core.data import conf
 
 
 class HTTPHandler(urllib2.HTTPHandler):
+    """
+    The hook http_requests function ensures that the chunk function is working properly.
+    """
 
     def _hook(self, request):
         host = request.get_host()

--- a/lib/request/httphandler.py
+++ b/lib/request/httphandler.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# @Time    : 2019/3/16 2:48 PM
+# @Author  : w8ay
+# @File    : httphandler.py
+import urllib2
+import httplib
+from lib.core.data import conf
+
+
+class HTTPHandler(urllib2.HTTPHandler):
+
+    def _hook(self, request):
+        host = request.get_host()
+        if not host:
+            raise urllib2.URLError('no host given')
+
+        if request.has_data():  # POST
+            data = request.get_data()
+            if not request.has_header('Content-type'):
+                request.add_unredirected_header(
+                    'Content-type',
+                    'application/x-www-form-urlencoded')
+            if not request.has_header('Content-length') and not conf.chunk:
+                request.add_unredirected_header(
+                    'Content-length', '%d' % len(data))
+
+        sel_host = host
+        if request.has_proxy():
+            scheme, sel = urllib2.splittype(request.get_selector())
+            sel_host, sel_path = urllib2.splithost(sel)
+
+        if not request.has_header('Host'):
+            request.add_unredirected_header('Host', sel_host)
+        for name, value in self.parent.addheaders:
+            name = name.capitalize()
+            if not request.has_header(name):
+                request.add_unredirected_header(name, value)
+        return request
+
+    http_request = _hook


### PR DESCRIPTION
refer:https://github.com/sqlmapproject/sqlmap/issues/3535
Bypassing some waf by using add headers for `Transfer-Encoding:Chunked`

I added a `--chunk` parameter option.when use it, it will convert all requests into chunks .
I defined the chunking keyword `CHUNKED_KEYWORDS` in `setting.py`, ensuring that each chunk does not contain a defined keyword.