### PR TITLE
Fix duplicate paramDict elements bug

### DIFF
--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -310,7 +310,7 @@ def _setRequestParams():
                                 conf.paramDict[place]["%s #%d%s" % (header, i + 1, kb.customInjectionMark)] = "%s,%s" % (header, "".join("%s%s" % (parts[j], kb.customInjectionMark if i == j else "") for j in xrange(len(parts))))
                             conf.httpHeaders[index] = (header, value.replace(kb.customInjectionMark, ""))
                 else:
-                    parts = value.split(kb.customInjectionMark)
+                    parts = [_ for _ in value.split(kb.customInjectionMark) if _]
 
                     for i in xrange(len(parts) - 1):
                         name = None


### PR DESCRIPTION
sqlmap parse some json may generate duplicated paramDict elements

for example, when sqlmap parse a json data:

`{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}`

the `conf.paramDict['POST']` value will is:

```
'JSON #1*' (90737040) = {unicode} u'{"employees":[{"firstName*":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #2*' (70483568) = {unicode} u'{"employees":[{"firstName":"Bill*","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #3*' (90737472) = {unicode} u'{"employees":[{"firstName":"Bill*","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #4*' (90737136) = {unicode} u'{"employees":[{"firstName":"Bill","lastName*":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #5*' (90737232) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates*"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #6*' (90737184) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates*"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #7*' (90737280) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName*":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #8*' (90737328) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George*","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #9*' (90737376) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George*","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #10*' (90737424) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName*":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #11*' (90737520) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush*"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #12*' (90737568) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush*"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #13*' (90737616) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName*":"Thomas","lastName":"Carter"}]}'
'JSON #14*' (90737664) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas*","lastName":"Carter"}]}'
'JSON #15*' (90737712) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas*","lastName":"Carter"}]}'
'JSON #16*' (90737760) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName*":"Carter"}]}'
'JSON #17*' (90737808) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter*"}]}'
'JSON #18*' (90737856) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter*"}]}'
```

for example : the `JSON #17` same with `JSON #18`.

there should be only have  `JSON #12`, so it generated six duplicate elements.

one of the two adjacent data is duplicated. The reason for generating duplicate data is that there is a null value when  split data use `parts = kb.customInjectionMark)`, so we should need remove null value 

the fixed result:

```
'JSON #1*' (90979760) = {unicode} u'{"employees":[{"firstName*":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #2*' (91152576) = {unicode} u'{"employees":[{"firstName":"Bill*","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #3*' (91152672) = {unicode} u'{"employees":[{"firstName":"Bill","lastName*":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #4*' (91152528) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates*"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #5*' (91152624) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName*":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #6*' (91152720) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George*","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #7*' (91152768) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName*":"Bush"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #8*' (91152816) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush*"},{"firstName":"Thomas","lastName":"Carter"}]}'
'JSON #9*' (91152864) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName*":"Thomas","lastName":"Carter"}]}'
'JSON #10*' (91152912) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas*","lastName":"Carter"}]}'
'JSON #11*' (91152960) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName*":"Carter"}]}'
'JSON #12*' (91153008) = {unicode} u'{"employees":[{"firstName":"Bill","lastName":"Gates"},{"firstName":"George","lastName":"Bush"},{"firstName":"Thomas","lastName":"Carter*"}]}'
```