### PR TITLE
Fix broken requests file parsing due to missing indent

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -312,10 +312,10 @@ def _setRequestFromFile():
                         conf.multipleTargets = True
                     seen.add(url)
 
-            if url is None:
-                errMsg = "specified file '%s' " % requestFile
-                errMsg += "does not contain a valid HTTP request"
-                raise SqlmapDataException(errMsg)
+                if url is None:
+                    errMsg = "specified file '%s' " % requestFile
+                    errMsg += "does not contain a valid HTTP request"
+                    raise SqlmapDataException(errMsg)
 
     if conf.secondReq:
         conf.secondReq = safeExpandUser(conf.secondReq)


### PR DESCRIPTION
Commit 4e7eefe2a introduced the possibility to pass multiple requests
files. Due to missing indent, the url parameter does not get set if it
is not a Burp Suite log or Web Scarab file and thus breaks parsing of
regular request files. Fix this by adding the missing indent.

Signed-off-by: Michael Niewöhner <michael.niewoehner@8com.de>