### PR TITLE
Detecting errors when standard status code and custom reply

### DIFF
--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -370,6 +370,9 @@ def cmdLineParser(argv=None):
         detection.add_argument("--code", dest="code", type=int,
             help="HTTP code to match when query is evaluated to True")
 
+        detection.add_argument("--error-string", dest="errorString",
+            help="String to match when the database encountered an error")
+
         detection.add_argument("--smart", dest="smart", action="store_true",
             help="Perform thorough tests only if positive heuristic(s)")
 

--- a/lib/parse/html.py
+++ b/lib/parse/html.py
@@ -14,6 +14,7 @@ from lib.core.common import parseXmlFile
 from lib.core.data import kb
 from lib.core.data import paths
 from lib.core.threads import getCurrentThreadData
+from lib.core.data import conf
 
 class HTMLHandler(ContentHandler):
     """
@@ -80,7 +81,11 @@ def htmlParser(page):
     kb.cache.parsedDbms[key] = handler.dbms
 
     # generic SQL warning/error messages
-    if re.search(r"SQL (warning|error|syntax)", page, re.I):
+    if conf.errorString:
+        error=conf.errorString
+    else:
+        error=r"SQL (warning|error|syntax)"
+    if re.search(error, page, re.I):
         handler._markAsErrorPage()
 
     return handler.dbms

--- a/sqlmap.conf
+++ b/sqlmap.conf
@@ -350,6 +350,10 @@ regexp =
 # code)
 # code = 
 
+# String to match within the raw response when the query returns a database error
+# Refer to the user's manual for further details.
+errorString = 
+
 # Conduct thorough tests only if positive heuristic(s).
 # Valid: True or False
 smart = False


### PR DESCRIPTION
This is a very simple PR which adds a new option, error-string, allowing sqlmap to detect SQL errors when the status code report is still correct(ie 200) but errors out, in the case that the error message outputted by the website has been customized by the sysadmin.

This is as quick of a PR as it can get, so tell me if there's any documentation I should fill out about this option or anything else!