### PR TITLE
Fix regression introduced by b3cdec5

### DIFF
--- a/plugins/dbms/postgresql/filesystem.py
+++ b/plugins/dbms/postgresql/filesystem.py
@@ -32,7 +32,7 @@ class Filesystem(GenericFilesystem):
 
         return self.udfEvalCmd(cmd=remoteFile, udfName="sys_fileread")
 
-    def writeFile(self, localFile, remoteFile, fileType=None, forceCheck=False):
+    def unionWriteFile(self, localFile, remoteFile, fileType=None, forceCheck=False):
         errMsg = "PostgreSQL does not support file upload with UNION "
         errMsg += "query SQL injection technique"
         raise SqlmapUnsupportedFeatureException(errMsg)


### PR DESCRIPTION
I have a demo setup with a vulnerable webapp with a Postgres DB in the backend. The webapp is vulnerable for stacked-queries SQLi. When I try to `--udf-inject`, Sqlmap complains that "PostgreSQL does not support file upload with UNION query SQL injection technique".
This used to work in former Sqlmap releases.

I did a "git bisect" to find the commit that broke my scenario, it is b3cdec547b2976ebf0b8e1a8f67d7032d4aa9ae3. The relevant change is in the file `plugins/dbms/postgresql/filesystem.py`, where the function unionWriteFile was renamed to writeFile.
This pull request reverts the chance and fixes the problem for me.