### PR TITLE
Support IPv6 literals in the proxy switch

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -995,7 +995,7 @@ def _setHTTPHandlers():
                 errMsg = "invalid proxy address '%s' ('%s')" % (conf.proxy, getSafeExString(ex))
                 raise SqlmapSyntaxException(errMsg)
 
-            hostnamePort = _.netloc.split(":")
+            hostnamePort = _.netloc.rsplit(":", 1)
 
             scheme = _.scheme.upper()
             hostname = hostnamePort[0]


### PR DESCRIPTION
IPv6 literals can have colons in the address portion; therefore, the correct way to split them is from the right side, at most once.