### PR TITLE
Tamper proposal - bypass weak "keywords stripping" filters

### DIFF
--- a/tamper/unstripkeywords.py
+++ b/tamper/unstripkeywords.py
@@ -21,6 +21,9 @@ def tamper(payload, **kwargs):
     """
     Transforms keywords ('SELECT') so they are valid when stripped once ('SELSELECTECT')
 
+    Keywords can be set with 'UNSTRIP_KEYWORDS' environment variable:
+        $ export UNSTRIP_KEYWORDS=select,union
+
     Tested against:
         * MySQL 5.7
 

--- a/tamper/unstripkeywords.py
+++ b/tamper/unstripkeywords.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2019 sqlmap developers (http://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+from re import finditer, search
+from os import environ
+from math import ceil, floor
+from lib.core.compat import xrange
+from lib.core.data import kb
+from lib.core.enums import PRIORITY
+
+__priority__ = PRIORITY.LOW
+
+def dependencies():
+    pass
+
+def tamper(payload, **kwargs):
+    """
+    Transforms keywords ('SELECT') so they are valid when stripped once ('SELSELECTECT')
+
+    Tested against:
+        * MySQL 5.7
+
+    Notes:
+        * Useful to bypass weak filters based on keywords stripping.
+
+    >>> tamper('SELECT id FROM users UNION SELECT NULL')
+    'SELSELECTECT id FROM users UNUNIONION SELSELECTECT NULL
+    """
+
+    retVal = payload
+    keywords = ['SELECT', 'UNION', 'WHERE', 'SUBSTR'];
+
+    if 'UNSTRIP_KEYWORDS' in environ:
+        keywords = environ['UNSTRIP_KEYWORDS'].upper().split(',')
+
+    if payload:
+        for keyword in keywords:
+            if keyword in payload and search(r"(?i)[`\"'\[]%s[`\"'\]]" % word, retVal) is None:
+                retVal = retVal.replace(word, word[:int(floor(len(word)/2))] + word + word[int(ceil(len(word)/2)):])
+
+    return retVal


### PR DESCRIPTION
This tamper simply translates `SELECT` into `SELSELECTECT`.

If it exists, environment variable `UNSTRIP_KEYWORDS` is used as a comma-separated list of keywords to process. Default keywords are `['SELECT', 'UNION', 'WHERE', 'SUBSTR']`.

Is it an acceptable way of passing parameters to a tamper script ? Is there a better way ?
Any suggestion for other default keywords ?

Cheers :)