### PR TITLE
Python 3 binary-character fixes for two urllib requests 

### DIFF
--- a/lib/utils/api.py
+++ b/lib/utils/api.py
@@ -713,7 +713,7 @@ def _client(url, options=None):
     try:
         data = None
         if options is not None:
-            data = jsonize(options)
+            data = jsonize(options).encode("utf-8")
         headers = {"Content-Type": "application/json"}
 
         if DataStore.username or DataStore.password:
@@ -721,7 +721,7 @@ def _client(url, options=None):
 
         req = _urllib.request.Request(url, data, headers)
         response = _urllib.request.urlopen(req)
-        text = response.read()
+        text = response.read().decode("utf-8")
     except:
         if options:
             logger.error("Failed to load and parse %s" % url)

--- a/lib/utils/search.py
+++ b/lib/utils/search.py
@@ -132,7 +132,7 @@ def _search(dork):
             regex = DUCKDUCKGO_REGEX
 
         try:
-            req = _urllib.request.Request(url, data=data, headers=requestHeaders)
+            req = _urllib.request.Request(url, data=data.encode("utf-8"), headers=requestHeaders)
             conn = _urllib.request.urlopen(req)
 
             requestMsg = "HTTP request:\nGET %s" % url


### PR DESCRIPTION
I got crashes and ugly output on sqlmapapi client under python3. I believe api.py patch is needed for proper function.
Quick grep over the urllib request calls has shown another case of same issue in search.py, probably rarely triggered and not showing as crash - test case is in the  commit message.