### PR TITLE
SQLite table dumping compatibility improvements.

### DIFF
--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -3287,9 +3287,9 @@ def parseSqliteTableSchema(value):
         table = {}
         columns = {}
 
-        for match in re.finditer(r"(\w+)[\"'`]?\s+(INT|INTEGER|TINYINT|SMALLINT|MEDIUMINT|BIGINT|UNSIGNED BIG INT|INT2|INT8|INTEGER|CHARACTER|VARCHAR|VARYING CHARACTER|NCHAR|NATIVE CHARACTER|NVARCHAR|TEXT|CLOB|LONGTEXT|BLOB|NONE|REAL|DOUBLE|DOUBLE PRECISION|FLOAT|REAL|NUMERIC|DECIMAL|BOOLEAN|DATE|DATETIME|NUMERIC)\b", decodeStringEscape(value), re.I):
+        for match in re.finditer(r"[(,]\s*[\"'`]?(\w+)[\"'`]?(?:\s+(INT|INTEGER|TINYINT|SMALLINT|MEDIUMINT|BIGINT|UNSIGNED BIG INT|INT2|INT8|INTEGER|CHARACTER|VARCHAR|VARYING CHARACTER|NCHAR|NATIVE CHARACTER|NVARCHAR|TEXT|CLOB|LONGTEXT|BLOB|NONE|REAL|DOUBLE|DOUBLE PRECISION|FLOAT|REAL|NUMERIC|DECIMAL|BOOLEAN|DATE|DATETIME|NUMERIC)\b)?", decodeStringEscape(value), re.I):
             retVal = True
-            columns[match.group(1)] = match.group(2)
+            columns[match.group(1)] = match.group(2) or "TEXT"
 
         table[safeSQLIdentificatorNaming(conf.tbl, True)] = columns
         kb.data.cachedColumns[conf.db] = table

--- a/plugins/generic/entries.py
+++ b/plugins/generic/entries.py
@@ -131,6 +131,8 @@ class Entries(object):
             try:
                 if Backend.isDbms(DBMS.INFORMIX):
                     kb.dumpTable = "%s:%s" % (conf.db, tbl)
+                elif Backend.isDbms(DBMS.SQLITE):
+                    kb.dumpTable = tbl
                 else:
                     kb.dumpTable = "%s.%s" % (conf.db, tbl)
 


### PR DESCRIPTION
I was working through the retired Holiday machine at HackTheBox. I noticed that `sqlmap` was unable to dump some of the tables for SQLite backend. There were two reasons for this:

1. SQLite supports implicit datatypes in the [create table definition][sqlite]. The regex in `lib/core/common.py` did not consider this, and was failing to parse the create table statement. The first patch fixes this. See below for a brief before and after example:

    ```
    [11:55:08] [INFO] testing connection to the target URL
    sqlmap resumed the following injection point(s) from stored session:
    ---
    Parameter: username (POST)
        Type: boolean-based blind
        Title: OR boolean-based blind - WHERE or HAVING clause (NOT)
        Payload: username=admin") OR NOT 8444=8444 AND ("NnOA"="NnOA&password=admin
    ---
    [11:55:08] [INFO] the back-end DBMS is SQLite
    back-end DBMS: SQLite
    [11:55:08] [INFO] retrieving the length of query output
    [11:55:08] [INFO] resumed: 54
    [11:55:08] [INFO] resumed: CREATE TABLE sessions (sid PRIMARY KEY, expired, sess)
    Database: SQLite_masterdb
    Table: sessions
    [0 columns]
    +--------+
    | Column |
    +--------+
    +--------+
    ```

    ```
    [11:34:37] [INFO] the back-end DBMS is SQLite
    back-end DBMS: SQLite
    [11:34:37] [INFO] retrieving the length of query output
    [11:34:37] [INFO] retrieved: 54
    [11:34:41] [INFO] retrieved: CREATE TABLE sessions (sid PRIMARY KEY, expired, sess)             
    Database: SQLite_masterdb
    Table: sessions
    [3 columns]
    +---------+------+
    | Column  | Type |
    +---------+------+
    | expired | TEXT |
    | sess    | TEXT |
    | sid     | TEXT |
    +---------+------+
    ```

2. When dumping a table that has more rows than `CHECK_ZERO_COLUMNS_THRESHOLD` an additional query is run. This query had the table name concatenated to db name, which was causing the query to fail and the column being filled with `NULL` values. As this is the same for each column, nothing is dumped from the table. The second patch addresses this by removing the db name.

Hope these are of some use.

[sqlite]: https://www.sqlite.org/lang_createtable.html