### PR TITLE
Make asterisk work with --csrf-token option

### DIFF
--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -400,7 +400,7 @@ def _setRequestParams():
         raise SqlmapGenericException(errMsg)
 
     if conf.csrfToken:
-        if not any(re.search(conf.csrfToken, ' '.join(_), re.I) for _ in (conf.paramDict.get(PLACE.GET, {}), conf.paramDict.get(PLACE.POST, {}), conf.paramDict.get(PLACE.COOKIE, {}))) and not re.search(r"\b%s\b" % conf.csrfToken, conf.data or "") and conf.csrfToken not in set(_[0].lower() for _ in conf.httpHeaders) and conf.csrfToken not in conf.paramDict.get(PLACE.COOKIE, {}):
+        if not any(re.search(conf.csrfToken, ' '.join(_), re.I) for _ in (conf.paramDict.get(PLACE.GET, {}), conf.paramDict.get(PLACE.POST, {}), conf.paramDict.get(PLACE.COOKIE, {}))) and not re.search(r"\b%s\b" % conf.csrfToken, conf.data or "") and conf.csrfToken not in set(_[0].lower() for _ in conf.httpHeaders) and conf.csrfToken not in conf.paramDict.get(PLACE.COOKIE, {}) and not all(re.search(conf.csrfToken, _, re.I) for _ in conf.paramDict.get(PLACE.URI, {}).values()):
             errMsg = "anti-CSRF token parameter '%s' not " % conf.csrfToken._original
             errMsg += "found in provided GET, POST, Cookie or header values"
             raise SqlmapGenericException(errMsg)

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -1125,11 +1125,13 @@ class Connect(object):
             if token:
                 token.value = token.value.strip("'\"")
 
-                for candidate in (PLACE.GET, PLACE.POST):
+                for candidate in (PLACE.GET, PLACE.POST, PLACE.CUSTOM_POST, PLACE.URI):
                     if candidate in conf.parameters:
-                        if candidate == PLACE.GET and get:
+                        if candidate == PLACE.URI and uri:
+                            uri = _adjustParameter(uri, token.name, token.value)
+                        elif candidate == PLACE.GET and get:
                             get = _adjustParameter(get, token.name, token.value)
-                        elif candidate == PLACE.POST and post:
+                        elif candidate in [PLACE.POST, PLACE.CUSTOM_POST] and post:
                             post = _adjustParameter(post, token.name, token.value)
 
                 for i in xrange(len(conf.httpHeaders)):


### PR DESCRIPTION
`--csrf-token` option works well if specify parameter through `-p csrf` explicitly.
For some user, who didn't trace code that deep, may encounter that 
`[CRITICAL] anti-CSRF token parameter 'csrf-token' not found in provided GET, POST, Cookie or header values`, when using asterisk in commands or request files without `-p`. For example, `--data "id=1*&csrf=xxx"`
This commit solves the problem mentioned above, make `--csrf-token` more general in **sqlmap**.