### PR TITLE
Changed get logs to handle ints correctly

### DIFF
--- a/lib/utils/api.py
+++ b/lib/utils/api.py
@@ -601,7 +601,7 @@ def scan_log_limited(taskid, start, end):
         logger.warning("[%s] Invalid task ID provided to scan_log_limited()" % taskid)
         return jsonize({"success": False, "message": "Invalid task ID"})
 
-    if not start.isdigit() or not end.isdigit() or end < start:
+    if not start.isdigit() or not end.isdigit() or int(end) < int(start):
         logger.warning("[%s] Invalid start or end value provided to scan_log_limited()" % taskid)
         return jsonize({"success": False, "message": "Invalid start or end value, must be digits"})
 


### PR DESCRIPTION
When trying to get the logs from line 1 to 20 an error message is returned as "Invalid start or end value, must be digits"

This is because we are doing ```end < start ``` when end and start are both Strings we should be doing ```int(end) < int(start)``` 