### PR TITLE
Escaping UNION query to prevent bug described in issue #4505

### DIFF
--- a/lib/techniques/union/use.py
+++ b/lib/techniques/union/use.py
@@ -253,7 +253,7 @@ def unionUse(expression, unpack=True, dump=False):
                 query = expression.replace(expressionFields, "ARRAY_AGG('%s'||%s||'%s')::text" % (kb.chars.start, ("||'%s'||" % kb.chars.delimiter).join("COALESCE(%s::text,' ')" % field for field in expressionFieldsList), kb.chars.stop), 1)
             elif Backend.isDbms(DBMS.MSSQL):
                 query = "'%s'+(%s FOR JSON AUTO, INCLUDE_NULL_VALUES)+'%s'" % (kb.chars.start, expression, kb.chars.stop)
-            output = _oneShotUnionUse(query, False)
+            output = _oneShotUnionUse(unescaper.escape(query), False)
             value = parseUnionPage(output)
             kb.jsonAggMode = False
 


### PR DESCRIPTION
This is proposed fix for the bug described in issue #4505 

### Fix Description
The issue is caused by unescaped data separators (start, stop and delimiter) in the payload. When the web server displays the payload on the web page, the sqlmap parser incorrectly detects the payload as a result data and it returns its content.
The solution is to simply escape data separators.

### Testing
I dev tested the fix on following DMBS types:
:heavy_check_mark: MySQL
:heavy_check_mark: Oracle
:heavy_check_mark: PostgreSQL

I haven't been able to test it on:
:x: Microsoft SQL