### PR TITLE
Added proxy support for websocket connections

### DIFF
--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -506,9 +506,23 @@ class Connect(object):
                 url = getBytes(url)  # Note: Python3 requires text while Python2 has problems when mixing text with binary POST
 
             if webSocket:
+                ws_proxy_port = None
+                ws_proxy_host = None
+                ws_proxy_auth = None
+                
+                if conf.proxy:
+                    ws_proxy_uri = _urllib.parse.urlsplit(conf.proxy)
+                    ws_proxy_port = ws_proxy_uri.port
+                    ws_proxy_host = ws_proxy_uri.netloc.split(":")[0]
+
+                if conf.proxyCred:
+                    ws_proxy_auth = conf.proxyCred.split(":")
+
                 ws = websocket.WebSocket()
                 ws.settimeout(WEBSOCKET_INITIAL_TIMEOUT if kb.webSocketRecvCount is None else timeout)
-                ws.connect(url, header=("%s: %s" % _ for _ in headers.items() if _[0] not in ("Host",)), cookie=cookie)  # WebSocket will add Host field of headers automatically
+                ws.connect(url, header=("%s: %s" % _ for _ in headers.items() if _[0] not in ("Host",)), cookie=cookie, 
+                            http_proxy_host=ws_proxy_host, http_proxy_port=ws_proxy_port, 
+                            http_proxy_auth=ws_proxy_auth)  # WebSocket will add Host field of headers automatically
                 ws.send(urldecode(post or ""))
 
                 _page = []

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -509,11 +509,13 @@ class Connect(object):
                 ws_proxy_port = None
                 ws_proxy_host = None
                 ws_proxy_auth = None
+                ws_proxy_scheme = None
                 
                 if conf.proxy:
                     ws_proxy_uri = _urllib.parse.urlsplit(conf.proxy)
                     ws_proxy_port = ws_proxy_uri.port
                     ws_proxy_host = ws_proxy_uri.netloc.split(":")[0]
+                    ws_proxy_scheme = ws_proxy_uri.scheme
 
                 if conf.proxyCred:
                     ws_proxy_auth = conf.proxyCred.split(":")
@@ -522,7 +524,7 @@ class Connect(object):
                 ws.settimeout(WEBSOCKET_INITIAL_TIMEOUT if kb.webSocketRecvCount is None else timeout)
                 ws.connect(url, header=("%s: %s" % _ for _ in headers.items() if _[0] not in ("Host",)), cookie=cookie, 
                             http_proxy_host=ws_proxy_host, http_proxy_port=ws_proxy_port, 
-                            http_proxy_auth=ws_proxy_auth)  # WebSocket will add Host field of headers automatically
+                            http_proxy_auth=ws_proxy_auth, proxy_type=ws_proxy_scheme)  # WebSocket will add Host field of headers automatically
                 ws.send(urldecode(post or ""))
 
                 _page = []

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -514,7 +514,7 @@ class Connect(object):
                 if conf.proxy:
                     ws_proxy_uri = _urllib.parse.urlsplit(conf.proxy)
                     ws_proxy_port = ws_proxy_uri.port
-                    ws_proxy_host = ws_proxy_uri.netloc.split(":")[0]
+                    ws_proxy_host = ws_proxy_uri.hostname
                     ws_proxy_scheme = ws_proxy_uri.scheme
 
                 if conf.proxyCred:


### PR DESCRIPTION
The websocket implementation in sqlmap did not use any proxy configurations provided via the commandline options.
This pull requests adds proxy support for websocket connections and also support for proxy-cred options. However, it does not support the proxy-file option.

With some limited testing, http, socks4 and socks5 options seems to work. However, https proxy option requires further investigation as it currently throws an error, which apparently relates to how websocket-client library handles proxies.