### PR TITLE
Fixed name 're' is not defined.

### DIFF
--- a/thirdparty/ansistrm/ansistrm.py
+++ b/thirdparty/ansistrm/ansistrm.py
@@ -5,6 +5,7 @@
 
 import logging
 import sys
+import re
 
 from lib.core.settings import IS_WIN
 


### PR DESCRIPTION
Fixed NameError: name 're' is not defined.
're' not imported in ./thirdparty/ansistrm/ansistrm.py