### PR TITLE
Use swagger as the source for targets

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -1793,7 +1793,7 @@ def _cleanupOptions():
     if conf.tmpPath:
         conf.tmpPath = ntToPosixSlashes(normalizePath(conf.tmpPath))
 
-    if any((conf.googleDork, conf.logFile, conf.bulkFile, conf.forms, conf.crawlDepth, conf.stdinPipe)):
+    if any((conf.googleDork, conf.logFile, conf.bulkFile, conf.forms, conf.crawlDepth, conf.stdinPipe, conf.swaggerFile)):
         conf.multipleTargets = True
 
     if conf.optimize:
@@ -1939,6 +1939,9 @@ def _cleanupOptions():
 
     if conf.dummy:
         conf.batch = True
+
+    if conf.swaggerTags:
+        conf.swaggerTags = [_.strip() for _ in re.split(PARAMETER_SPLITTING_REGEX, conf.swaggerTags)]
 
     threadData = getCurrentThreadData()
     threadData.reset()

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -477,6 +477,31 @@ def _setBulkMultipleTargets():
         warnMsg = "no usable links found (with GET parameters)"
         logger.warn(warnMsg)
 
+def _setSwaggerMultipleTargets():
+    if not conf.swaggerFile:
+        return
+
+    infoMsg = "parsing multiple targets from swagger '%s'" % conf.swaggerFile
+    logger.info(infoMsg)
+
+    if not os.path.exists(conf.swaggerFile):
+        errMsg = "the specified list of targets does not exist"
+        raise SqlmapFilePathException(errMsg)
+
+    if checkFile(conf.swaggerFile, False):
+        debugMsg = "swagger file '%s' checks out" % conf.swaggerFile
+        logger.debug(debugMsg)
+
+        for target in parseRequestFile(conf.swaggerFile):
+            kb.targets.add(target)
+
+    else:
+        errMsg = "the specified list of targets is not a file "
+        errMsg += "nor a directory"
+        raise SqlmapFilePathException(errMsg)
+
+
+
 def _findPageForms():
     if not conf.forms or conf.crawlDepth:
         return
@@ -2677,7 +2702,7 @@ def _basicOptionValidation():
         errMsg = "maximum number of used threads is %d avoiding potential connection issues" % MAX_NUMBER_OF_THREADS
         raise SqlmapSyntaxException(errMsg)
 
-    if conf.forms and not any((conf.url, conf.googleDork, conf.bulkFile)):
+    if conf.forms and not any((conf.url, conf.googleDork, conf.bulkFile, conf.swaggerFile)):
         errMsg = "switch '--forms' requires usage of option '-u' ('--url'), '-g' or '-m'"
         raise SqlmapSyntaxException(errMsg)
 
@@ -2787,7 +2812,7 @@ def _basicOptionValidation():
         errMsg = "value for option '--union-char' must be an alpha-numeric value (e.g. 1)"
         raise SqlmapSyntaxException(errMsg)
 
-    if conf.hashFile and any((conf.direct, conf.url, conf.logFile, conf.bulkFile, conf.googleDork, conf.configFile, conf.requestFile, conf.updateAll, conf.smokeTest, conf.wizard, conf.dependencies, conf.purge, conf.listTampers)):
+    if conf.hashFile and any((conf.direct, conf.url, conf.logFile, conf.bulkFile, conf.swaggerFile, conf.googleDork, conf.configFile, conf.requestFile, conf.updateAll, conf.smokeTest, conf.wizard, conf.dependencies, conf.purge, conf.listTampers)):
         errMsg = "option '--crack' should be used as a standalone"
         raise SqlmapSyntaxException(errMsg)
 
@@ -2855,7 +2880,7 @@ def init():
 
     parseTargetDirect()
 
-    if any((conf.url, conf.logFile, conf.bulkFile, conf.requestFile, conf.googleDork, conf.stdinPipe)):
+    if any((conf.url, conf.logFile, conf.bulkFile, conf.swaggerFile, conf.requestFile, conf.googleDork, conf.stdinPipe)):
         _setHostname()
         _setHTTPTimeout()
         _setHTTPExtraHeaders()
@@ -2871,6 +2896,7 @@ def init():
         _doSearch()
         _setStdinPipeTargets()
         _setBulkMultipleTargets()
+        _setSwaggerMultipleTargets()
         _checkTor()
         _setCrawler()
         _findPageForms()

--- a/lib/core/optiondict.py
+++ b/lib/core/optiondict.py
@@ -18,6 +18,8 @@ optDict = {
         "requestFile": "string",
         "sessionFile": "string",
         "googleDork": "string",
+        "swaggerFile": "string",
+        "swaggerTags": "string",
         "configFile": "string",
     },
 

--- a/lib/core/swagger.py
+++ b/lib/core/swagger.py
@@ -88,6 +88,9 @@ def _example(swagger, refPath):
 def parse(content, tags):
     """
     Parses Swagger OpenAPI 3.x.x JSON documents
+
+    Target injectable parameter values are generated from the "example" properties.
+    Only property-level "example" is supported. The "examples" property is not supported.
     """
 
     try:

--- a/lib/core/swagger.py
+++ b/lib/core/swagger.py
@@ -29,8 +29,15 @@ class Operation:
         return list(filter(lambda p: (p["in"] in types), self.parameters()))
 
     def bodyRef(self):
+        # OpenAPI v3
         if "requestBody" in self.props:
             return self.props["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+        # swagger v2
+        elif "parameters" in self.props:
+            inParameters = self.parametersForTypes(["body"])
+            if not isinstance(inParameters, list) or len(inParameters) < 1:
+                return None
+            return inParameters[0]["schema"]["$ref"]
         return None
 
     # header injection is not currently supported

--- a/lib/core/swagger.py
+++ b/lib/core/swagger.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2021 sqlmap developers (https://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+import json
+
+from lib.core.data import logger
+from lib.core.exception import SqlmapSyntaxException
+
+def _operationParameters(parameters, types):
+    return list(filter(lambda p: (p["in"] in types), parameters))
+
+def _operationQueryString(parameters):
+    queryParameters = _operationParameters(parameters, ["query"])
+    if len(queryParameters) < 1:
+        return None
+    queryString = ""
+    for qp in queryParameters:
+        queryString += "&%s=%s" %(qp["name"], qp["example"])
+
+    return queryString.replace('&', '', 1)
+
+def _operationPath(path, parameters):
+    pathParameters = _operationParameters(parameters, ["path"])
+    if len(pathParameters) < 1:
+        return path
+    parameterPath = path
+    for p in pathParameters:
+        parameterPath = parameterPath.replace("{%s}" %p["name"], "%s*" %p["example"])
+    return parameterPath
+
+def _ref(swagger, refPath):
+     paths = refPath.replace("#/", "", 1).split('/')
+     r = swagger
+     for p in paths:
+        r = r[p]
+     return r
+
+def _body(swagger, refPath):
+    body = {}
+    ref = _ref(swagger, refPath)
+    if "type" in ref and ref["type"] == "object" and "properties" in ref:
+        properties = ref["properties"]
+        for prop in properties:
+            if "example" in properties[prop]:
+                value = properties[prop]["example"]
+                body[prop] = value
+            elif "$ref" in properties[prop]:
+                body[prop] = _body(swagger, properties[prop]["$ref"])
+            elif properties[prop]["type"] == "array" and "$ref" in properties[prop]["items"]:
+                body[prop] =  [ _body(swagger, properties[prop]["items"]["$ref"]) ]
+
+    return body
+
+def parse(content, tags):
+    """
+    Parses Swagger OpenAPI 3.x.x JSON documents
+    """
+
+    try:
+        swagger = json.loads(content)
+
+        # extra validations
+        if "openapi" not in swagger or not swagger["openapi"].startswith("3."):
+          errMsg = "swagger must be OpenAPI 3.x.x!"
+          raise SqlmapSyntaxException(errMsg)
+
+        if ("servers" not in swagger or
+                not isinstance(swagger["servers"], list) or
+                len(swagger["servers"]) < 1 or
+                "url" not in swagger["servers"][0]):
+          errMsg = "swagger server is missing!"
+          raise SqlmapSyntaxException(errMsg)
+
+        server = swagger["servers"][0]["url"]
+
+        logger.info("swagger OpenAPI version '%s', server '%s'" %(swagger["openapi"], server))
+
+        for path in swagger["paths"]:
+            for operation in swagger["paths"][path]:
+                op =  swagger["paths"][path][operation]
+
+                # skip any operations without one of our tags
+                if tags is not None and not any(tag in op["tags"] for tag in tags):
+                    continue
+
+                body = {}
+                if "requestBody" in op:
+                  ref = op["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+                  body = _body(swagger, ref)
+
+                # header injection is not currently supported
+                if (len(_operationParameters(op["parameters"], ["query", "path"]))) < 1 and not body:
+                    logger.info("excluding path '%s', operation '%s' as there are no parameters to inject" %(path, operation))
+                    continue
+
+                url = None
+                method = None
+                data = None
+                cookie = None
+
+                parameterPath = _operationPath(path, op["parameters"])
+                qs = _operationQueryString(op["parameters"])
+                url = "%s%s" % (server, parameterPath)
+                method = operation.upper()
+                if body:
+                    data = json.dumps(body)
+
+                if qs is not None:
+                    url += "?" + qs
+
+                logger.debug("swagger url '%s', method '%s', data '%s', cookie '%s'" %(url, method, data, cookie))
+                yield (url, method, data, cookie, None)
+
+    except json.decoder.JSONDecodeError:
+        errMsg = "swagger file is not valid JSON"
+        raise SqlmapSyntaxException(errMsg)

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -141,6 +141,12 @@ def cmdLineParser(argv=None):
         target.add_argument("-g", dest="googleDork",
             help="Process Google dork results as target URLs")
 
+        target.add_argument("--swaggerFile", dest="swaggerFile",
+            help="Parse target(s) from a Swagger OpenAPI 3.x.x JSON file ")
+
+        target.add_argument("--swaggerTags", dest="swaggerTags",
+            help="Only process swagger operations that include one of these tags")
+
         target.add_argument("-c", dest="configFile",
             help="Load options from a configuration INI file")
 

--- a/lib/parse/configfile.py
+++ b/lib/parse/configfile.py
@@ -79,14 +79,14 @@ def configFileParser(configFile):
 
     mandatory = False
 
-    for option in ("direct", "url", "logFile", "bulkFile", "googleDork", "requestFile", "wizard"):
+    for option in ("direct", "url", "logFile", "bulkFile", "googleDork", "requestFile", "wizard", "swaggerFile"):
         if config.has_option("Target", option) and config.get("Target", option) or cmdLineOptions.get(option):
             mandatory = True
             break
 
     if not mandatory:
         errMsg = "missing a mandatory option in the configuration file "
-        errMsg += "(direct, url, logFile, bulkFile, googleDork, requestFile or wizard)"
+        errMsg += "(direct, url, logFile, bulkFile, googleDork, requestFile, wizard or swaggerFile)"
         raise SqlmapMissingMandatoryOptionException(errMsg)
 
     for family, optionData in optDict.items():

--- a/sqlmap.conf
+++ b/sqlmap.conf
@@ -32,6 +32,12 @@ requestFile =
 # Example: +ext:php +inurl:"&id=" +intext:"powered by "
 googleDork = 
 
+# Parse target(s) for a Swagger OpenAPI 3.x.x JSON file
+swaggerFile =
+
+# Only process swagger operations that have one of these tags (e.g. tagA,tagB)
+swaggerTags =
+
 
 # These options can be used to specify how to connect to the target URL.
 [Request]


### PR DESCRIPTION
Parse a JSON swagger document describing all APIs, for possible targets. Specify the swagger document using the --swaggerFile option.

The swagger must contain examples which sqlmap will use as parameter values to inject.

Addresses issue https://github.com/sqlmapproject/sqlmap/issues/3140