### PR TITLE
support for URLs containing credentials

### DIFF
--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -1721,13 +1721,13 @@ def parseTargetUrl():
 
     try:
         urlSplit = _urllib.parse.urlsplit(conf.url)
+        hostnamePort = [urlSplit.hostname, urlSplit.port]
     except ValueError as ex:
         errMsg = "invalid URL '%s' has been given ('%s'). " % (conf.url, getSafeExString(ex))
         errMsg += "Please be sure that you don't have any leftover characters (e.g. '[' or ']') "
         errMsg += "in the hostname part"
         raise SqlmapGenericException(errMsg)
 
-    hostnamePort = urlSplit.netloc.split(":") if not re.search(r"\[.+\]", urlSplit.netloc) else filterNone((re.search(r"\[.+\]", urlSplit.netloc).group(0), re.search(r"\](:(?P<port>\d+))?", urlSplit.netloc).group("port")))
 
     conf.scheme = (urlSplit.scheme.strip().lower() or "http")
     conf.path = urlSplit.path.strip()
@@ -1736,8 +1736,8 @@ def parseTargetUrl():
     if conf.forceSSL:
         conf.scheme = re.sub(r"(?i)\A(http|ws)\Z", r"\g<1>s", conf.scheme)
 
-    conf.ipv6 = conf.hostname != conf.hostname.strip("[]")
-    conf.hostname = conf.hostname.strip("[]").replace(kb.customInjectionMark, "")
+    conf.ipv6 = ":" in conf.hostname
+    conf.hostname = conf.hostname.replace(kb.customInjectionMark, "")
 
     try:
         conf.hostname.encode("idna")

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -1527,7 +1527,7 @@ def _setHostname():
 
     if conf.url:
         try:
-            conf.hostname = _urllib.parse.urlsplit(conf.url).netloc.split(':')[0]
+            conf.hostname = _urllib.parse.urlsplit(conf.url).hostname
         except ValueError as ex:
             errMsg = "problem occurred while "
             errMsg += "parsing an URL '%s' ('%s')" % (conf.url, getSafeExString(ex))


### PR DESCRIPTION
URLs containing credentials are not supported and using them as target URLs doesn't work as expected:
```
sqlmap -u 'http://user@127.0.0.1:80/dashboard/?id=123' --batch    

[CRITICAL] host 'user@127.0.0.1' does not exist
```
```
sqlmap -u 'http://user:pass@127.0.0.1:80/dashboard/?id=123' --batch

[CRITICAL] host 'user' does not exist
```
