### PR TITLE
Fix sqlite session file descriptor leak for blind injection

### DIFF
--- a/lib/techniques/blind/inference.py
+++ b/lib/techniques/blind/inference.py
@@ -556,6 +556,8 @@ def bisection(payload, expression, length=None, charsetType=None, firstChar=None
                                     output += status if _ != length else " " * len(status)
 
                                     dataToStdout("\r[%s] [INFO] retrieved: %s" % (time.strftime("%X"), output))
+                        if conf.get("hashDB"):
+                            conf.hashDB.close()
 
                 runThreads(numThreads, blindThread, startThreadMsg=False)
 

--- a/lib/utils/hashdb.py
+++ b/lib/utils/hashdb.py
@@ -62,6 +62,7 @@ class HashDB(object):
         threadData = getCurrentThreadData()
         try:
             if threadData.hashDBCursor:
+                threadData.hashDBCursor.connection.commit()
                 threadData.hashDBCursor.close()
                 threadData.hashDBCursor.connection.close()
                 threadData.hashDBCursor = None


### PR DESCRIPTION
Fix sqlite session file descriptor leak for blind injection, see #4972.

The cursor and connection for a thread are never closed when using `blindThread()`. It results in opening as much fd as threads without closing them when threads are finished. If the fd limit of the user is too low compared to the number of threads required, the error `unable to connect to the target URL ('Too many open files')` and `unable to open database file` will pop out and stop the DB extraction.

You can see the fd leak by monitoring the number of fd opened during the sqlmap execution with `lsof -p [sqlmap PID]`. It grows constantly. If you didn't observe this bug, check your fd limit with `ulimit -Sn` and reduce it in `/etc/security/limits.conf`.