### PR TITLE
Add link of Simplified Chinese translation of wiki pages

### DIFF
--- a/doc/translations/README-zh-CN.md
+++ b/doc/translations/README-zh-CN.md
@@ -43,6 +43,7 @@ sqlmap 可以运行在 [Python](https://www.python.org/download/)  **2.6**, **2.
 * RSS 订阅: https://github.com/sqlmapproject/sqlmap/commits/master.atom
 * Issue tracker: https://github.com/sqlmapproject/sqlmap/issues
 * 使用手册: https://github.com/sqlmapproject/sqlmap/wiki
+  * 简体中文版: https://github.com/kvko/sqlmap-wiki-zhcn
 * 常见问题 (FAQ): https://github.com/sqlmapproject/sqlmap/wiki/FAQ
 * Twitter: [@sqlmap](https://twitter.com/sqlmap)
 * 教程: [https://www.youtube.com/user/inquisb/videos](https://www.youtube.com/user/inquisb/videos)


### PR DESCRIPTION
Hi there,

We've translated the wiki pages in Simplified Chinese and followed up the updates for years.
Maybe it's a good idea to guide Chinese users of sqlmap to visit the translated wiki. :)

We also put it on GitBook: https://sqlmap.kvko.live/

Thanks.