### PR TITLE
docs: Fix a few typos

### DIFF
--- a/thirdparty/fcrypt/fcrypt.py
+++ b/thirdparty/fcrypt/fcrypt.py
@@ -68,7 +68,7 @@ __all__ = ['crypt']
 # ----- BEGIN fcrypt.c LICENSE -----
 #
 # This library is free for commercial and non-commercial use as long as
-# the following conditions are aheared to.  The following conditions
+# the following conditions are adhered to.  The following conditions
 # apply to all code found in this distribution, be it the RC4, RSA,
 # lhash, DES, etc., code; not just the SSL code.  The SSL documentation
 # included with this distribution is covered by the same copyright terms

--- a/thirdparty/pydes/pyDes.py
+++ b/thirdparty/pydes/pyDes.py
@@ -245,7 +245,7 @@ class _baseDes(object):
 # 				    DES					    #
 #############################################################################
 class des(_baseDes):
-	"""DES encryption/decrytpion class
+	"""DES encryption/decryption class
 
 	Supports ECB (Electronic Code Book) and CBC (Cypher Block Chaining) modes.
 
@@ -685,7 +685,7 @@ class des(_baseDes):
 # 				Triple DES				    #
 #############################################################################
 class triple_des(_baseDes):
-	"""Triple DES encryption/decrytpion class
+	"""Triple DES encryption/decryption class
 
 	This algorithm uses the DES-EDE3 (when a 24 byte key is supplied) or
 	the DES-EDE2 (when a 16 byte key is supplied) encryption methods.


### PR DESCRIPTION
There are small typos in:
- thirdparty/fcrypt/fcrypt.py
- thirdparty/pydes/pyDes.py

Fixes:
- Should read `decryption` rather than `decrytpion`.
- Should read `adhered` rather than `aheared`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md