### PR TITLE
Add URL tampering scripts for crawling

### DIFF
--- a/lib/core/optiondict.py
+++ b/lib/core/optiondict.py
@@ -213,6 +213,7 @@ optDict = {
         "cleanup": "boolean",
         "crawlDepth": "integer",
         "crawlExclude": "string",
+        "urlTamper": "string",
         "csvDel": "string",
         "dumpFormat": "string",
         "encoding": "string",

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -652,6 +652,9 @@ def cmdLineParser(argv=None):
         general.add_argument("--crawl-exclude", dest="crawlExclude",
             help="Regexp to exclude pages from crawling (e.g. \"logout\")")
 
+        injection.add_argument("--url-tamper", dest="urlTamper",
+            help="Use given script(s) for tampering URLs during crawling.")
+
         general.add_argument("--csv-del", dest="csvDel",
             help="Delimiting character used in CSV output (default \"%s\")" % defaults.csvDel)
 

--- a/lib/utils/crawler.py
+++ b/lib/utils/crawler.py
@@ -58,6 +58,20 @@ def crawl(target, post=None, cookie=None):
                 with kb.locks.limit:
                     if threadData.shared.unprocessed:
                         current = threadData.shared.unprocessed.pop()
+                        if kb.urlTamperFunctions:
+                            for function in kb.urlTamperFunctions:
+                                hints = {}
+                                try:
+                                    current = function(url=current, hints=hints)
+                                except Exception as ex:
+                                    errMsg = "error occurred while running URL tamper "
+                                    errMsg += "function '%s' ('%s')" % (function.__name__, getSafeExString(ex))
+                                    logger.critical(errMsg)
+
+                                if not isinstance(current, six.string_types):
+                                    errMsg = "URL tamper function '%s' returns " % function.__name__
+                                    errMsg += "invalid payload type ('%s')" % type(payload)
+                                    logger.critical(errMsg)
                         if current in visited:
                             continue
                         elif conf.crawlExclude and re.search(conf.crawlExclude, current):

--- a/sqlmap.conf
+++ b/sqlmap.conf
@@ -731,6 +731,9 @@ crawlDepth = 0
 # Regexp to exclude pages from crawling (e.g. "logout").
 crawlExclude =
 
+# Tamper script for URL crawling
+urlTamper = 
+
 # Delimiting character used in CSV output.
 # Default: ,
 csvDel = ,


### PR DESCRIPTION
While crawling, it can be helpful to rewrite URLs before visiting them. One example would be rewriting http to https or parsing a `filename` GET parameter that leads to a redirect.

This pull requests adds the config option `--url-tamper` with functionality similiar to the existing tamper script. A url-tamper script must have a function `tamper(url, **kwargs)` that returns the tampered URL.

Example URL-tamper script:
```
baseURL = example.org

# Rewrites baseURL/redirect.php?filename=$filename to baseURL/$filename
def tamper(url, **kwargs):
    if "redirect.php" in url:
        filename = url.split("filename=", 1)[1]
        new_url = "%s/%s" % (baseURL, filename)
        return new_url
    return url
```