### PR TITLE
New tamper scripts for XML encoding

### DIFF
--- a/tamper/decentities.py
+++ b/tamper/decentities.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2022 sqlmap developers (https://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+from lib.core.enums import PRIORITY
+
+__priority__ = PRIORITY.LOW
+
+def dependencies():
+    pass
+
+def tamper(payload, **kwargs):
+    """
+    HTML encode in decimal (using code points) all characters (e.g. ' -> &#39;)
+
+    >>> tamper("1' AND SLEEP(5)#")
+    '&#49;&#39;&#32;&#65;&#78;&#68;&#32;&#83;&#76;&#69;&#69;&#80;&#40;&#53;&#41;&#35;'
+    """
+
+    retVal = payload
+
+    if payload:
+        retVal = ""
+        i = 0
+
+        while i < len(payload):
+            retVal += "&#%s;" % ord(payload[i])
+            i += 1
+
+    return retVal

--- a/tamper/hexentities.py
+++ b/tamper/hexentities.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2022 sqlmap developers (https://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+from lib.core.enums import PRIORITY
+
+__priority__ = PRIORITY.LOW
+
+def dependencies():
+    pass
+
+def tamper(payload, **kwargs):
+    """
+    HTML encode in hexadecimal (using code points) all characters (e.g. ' -> &#x31;)
+
+    >>> tamper("1' AND SLEEP(5)#")
+    '&#x31;&#x27;&#x20;&#x41;&#x4e;&#x44;&#x20;&#x53;&#x4c;&#x45;&#x45;&#x50;&#x28;&#x35;&#x29;&#x23;'
+    """
+
+    retVal = payload
+
+    if payload:
+        retVal = ""
+        i = 0
+
+        while i < len(payload):
+            retVal += "&#x%s;" % format(ord(payload[i]), "x")
+            i += 1
+
+    return retVal


### PR DESCRIPTION
Hello,
I am opening this pull request to contribute to the sqlmap project with two tamper scripts I have created:

- **decentities.py**: HTML encode in decimal (using code points) all characters (e.g. ' -> `&#39;`)
- **hexentities.py**: HTML encode in hexadecimal (using code points) all characters (e.g. ' -> `&#x31;`)

I am aware that the following tamper already exists: https://github.com/sqlmapproject/sqlmap/blob/master/tamper/htmlencode.py but this tamper is meant to encode non-alphanumeric characters, while my tamper encodes the entire payload. If for example the string "UNION" is blocked by a WAF or a filter, htmlencode.py would not help but decentities.py or hexentities.py would.

**What scenarios can my tampers be useful for?** For requests that support XML. 
XML supports character encoding using the same numeric escape sequences as HTML, allowing special characters to be included in the text content of elements without breaking the syntax.

The following PortSwigger lab: https://portswigger.net/web-security/sql-injection/lab-sql-injection-with-filter-bypass-via-xml-encoding allows to test this scenario. It is recommended to save the vulnerable request to a file and set a custom marker, to set the payload injection point.

I hope this suggestion will be useful,
Best regards.