### PR TITLE
fixes #5197

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -2675,7 +2675,7 @@ def _basicOptionValidation():
             logger.warning(warnMsg)
 
 
-    if conf.cookieDel and len(conf.cookieDel):
+    if conf.cookieDel and len(conf.cookieDel) != 1:
         errMsg = "option '--cookie-del' should contain a single character (e.g. ';')"
         raise SqlmapSyntaxException(errMsg)
 


### PR DESCRIPTION
Changes `--cookie-del` error checking to throw error if length of cookieDel value is not equal to **_1_**.
(It used to throw if it was not equal to **_0_** which ALWAYS returned true if the option was being used)

See issue #5197 