### PR TITLE
Better handling of CookieJar Runtime Exception

### DIFF
--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -587,14 +587,9 @@ class Connect(object):
 
                 if not getRequestHeader(req, HTTP_HEADER.COOKIE) and conf.cj:
                     conf.cj._policy._now = conf.cj._now = int(time.time())
-                    while True:
-                        try:
-                            cookies = conf.cj._cookies_for_request(req)
-                        except RuntimeError:    # NOTE: https://github.com/sqlmapproject/sqlmap/issues/5187
-                            time.sleep(1)
-                        else:
-                            requestHeaders += "\r\n%s" % ("Cookie: %s" % ";".join("%s=%s" % (getUnicode(cookie.name), getUnicode(cookie.value)) for cookie in cookies))
-                            break
+                    with conf.cj._cookies_lock:
+                        cookies = conf.cj._cookies_for_request(req)
+                    requestHeaders += "\r\n%s" % ("Cookie: %s" % ";".join("%s=%s" % (getUnicode(cookie.name), getUnicode(cookie.value)) for cookie in cookies))
 
                 if post is not None:
                     if not getRequestHeader(req, HTTP_HEADER.CONTENT_LENGTH) and not chunked:


### PR DESCRIPTION
Instead of waiting for the exception and sleeping in between, we can simply use the same lock used by the original cookiejar code (since we are already accessing private member), to prevent the exception from happening in the first place.

Fixes #5187