### PR TITLE
Fixing "/usr/bin/env: ‘python’: No such file or directory"

### DIFF
--- a/sqlmap.py
+++ b/sqlmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Copyright (c) 2006-2022 sqlmap developers (https://sqlmap.org/)


### PR DESCRIPTION
When you use "sqlmap --update" you receive this message: /usr/bin/env: ‘python’: No such file or directory

![image](https://user-images.githubusercontent.com/80774764/198846635-15cf5d25-38c4-4cff-ac06-f84fc712e3a2.png)

To fix it, only change "python" environment in sqlmap.py to "python3". You can create an environment or alias in your system called "python" to fix this issue too. The both options work.