### PR TITLE
Parse error when querying DISTINCT and multiple columns.

### DIFF
--- a/lib/core/agent.py
+++ b/lib/core/agent.py
@@ -625,7 +625,9 @@ class Agent(object):
         fieldsToCastStr = fieldsToCastStr or ""
 
         # Function
-        if re.search(r"\A\w+\(.*\)", fieldsToCastStr, re.I) or (fieldsSelectCase and "WHEN use" not in query) or fieldsSubstr:
+        if re.search(r"\A\w+\(.*\),", fieldsToCastStr, re.I) or (fieldsSelectCase and "WHEN use" not in query) or fieldsSubstr:
+            fieldsToCastList = splitFields(fieldsToCastStr)
+        elif re.search(r"\A\w+\(.*\)", fieldsToCastStr, re.I) or (fieldsSelectCase and "WHEN use" not in query) or fieldsSubstr:
             fieldsToCastList = [fieldsToCastStr]
         else:
             fieldsToCastList = splitFields(fieldsToCastStr)


### PR DESCRIPTION
I made a temporary fix, but I don't know if you like the code.

When combining DISTINCT with one or more queries `DISTINCT(idx),msg, ....` the columns are not rotated one by one when extracted, but are queried together.

