### PR TITLE
Fixes #5375

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -996,7 +996,7 @@ def _setPostprocessFunctions():
             for name, function in inspect.getmembers(module, inspect.isfunction):
                 try:
                     argspec = inspect.getargspec(function).args
-                except: # `inspect.getargspec` was removed in PY 3.11
+                except AttributeError: # `inspect.getargspec` was removed in PY 3.11
                     argspec = inspect.getfullargspec(function).args
                 if name == "postprocess" and argspec and all(_ in inspect.getargspec(function).args for _ in ("page", "headers", "code")):
                     found = True

--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -994,7 +994,11 @@ def _setPostprocessFunctions():
                 raise SqlmapSyntaxException("cannot import postprocess module '%s' (%s)" % (getUnicode(filename[:-3]), getSafeExString(ex)))
 
             for name, function in inspect.getmembers(module, inspect.isfunction):
-                if name == "postprocess" and inspect.getargspec(function).args and all(_ in inspect.getargspec(function).args for _ in ("page", "headers", "code")):
+                try:
+                    argspec = inspect.getargspec(function).args
+                except: # `inspect.getargspec` was removed in PY 3.11
+                    argspec = inspect.getfullargspec(function).args
+                if name == "postprocess" and argspec and all(_ in inspect.getargspec(function).args for _ in ("page", "headers", "code")):
                     found = True
 
                     kb.postprocessFunctions.append(function)


### PR DESCRIPTION
This pull request fixes a compatibility issue with Python >= 3.11. Uses drop-in replacement for removed function `inspect.getargspec`, which has been deprecated since Python 3.0.