### PR TITLE
Missing Support for TLSv1.3 - Disabled hostname and certificate validation

### DIFF
--- a/lib/request/httpshandler.py
+++ b/lib/request/httpshandler.py
@@ -69,6 +69,11 @@ class HTTPSConnection(_http_client.HTTPSConnection):
                     sock = create_sock()
                     if protocol not in _contexts:
                         _contexts[protocol] = ssl.SSLContext(protocol)
+
+                        # Disable certificate and hostname validation enabled by default with PROTOCOL_TLS_CLIENT
+                        _contexts[protocol].check_hostname = False
+                        _contexts[protocol].verify_mode = ssl.CERT_NONE
+
                         if getattr(self, "cert_file", None) and getattr(self, "key_file", None):
                             _contexts[protocol].load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
                         try:


### PR DESCRIPTION
Introduction of the `PROTOCOL_TLS_CLIENT` constant in Issue #5392 enables `ssl.CERT_REQUIRED` and `SSLContext.check_hostname`, which will restrict sqlmap from scanning endpoints that present unknown, self-signed, expired, or otherwise invalid certificates - including invalid Subject Names and Subject Alternative Names.

To address this issue, I created a patch that will allow sqlmap to accept these certificates.