### PR TITLE
Change the dump file name

### DIFF
--- a/lib/core/dump.py
+++ b/lib/core/dump.py
@@ -58,6 +58,7 @@ from lib.core.settings import WINDOWS_RESERVED_NAMES
 from lib.utils.safe2bin import safechardecode
 from thirdparty import six
 from thirdparty.magic import magic
+from plugins.generic.entries import G_column_name_list
 
 class Dump(object):
     """
@@ -449,7 +450,7 @@ class Dump(object):
 
                             dumpDbPath = tempDir
 
-            dumpFileName = conf.dumpFile or os.path.join(dumpDbPath, re.sub(r'[\\/]', UNSAFE_DUMP_FILEPATH_REPLACEMENT, "%s.%s" % (unsafeSQLIdentificatorNaming(table), conf.dumpFormat.lower())))
+            dumpFileName = conf.dumpFile or os.path.join(dumpDbPath, re.sub(r'[\\/]', UNSAFE_DUMP_FILEPATH_REPLACEMENT, "%s-%s.%s" % (unsafeSQLIdentificatorNaming(table),G_column_name_list[0],conf.dumpFormat.lower())))
             if not checkFile(dumpFileName, False):
                 try:
                     openFile(dumpFileName, "w+b").close()
@@ -470,7 +471,7 @@ class Dump(object):
                 if not appendToFile:
                     count = 1
                     while True:
-                        candidate = "%s.%d" % (dumpFileName, count)
+                        candidate = "%s-%02d.csv" % (dumpFileName.split('.csv')[0], count)
                         if not checkFile(candidate, False):
                             try:
                                 shutil.copyfile(dumpFileName, candidate)

--- a/plugins/generic/entries.py
+++ b/plugins/generic/entries.py
@@ -52,6 +52,7 @@ from lib.utils.pivotdumptable import pivotDumpTable
 from thirdparty import six
 from thirdparty.six.moves import zip as _zip
 
+G_column_name_list=['']
 class Entries(object):
     """
     This class defines entries' enumeration functionalities for plugins.
@@ -167,6 +168,7 @@ class Entries(object):
                 infoMsg = "fetching entries"
                 if conf.col:
                     infoMsg += " of column(s) '%s'" % colNames
+                G_column_name_list[0] = colString
                 infoMsg += " for table '%s'" % unsafeSQLIdentificatorNaming(tbl)
                 if METADB_SUFFIX not in conf.db:
                     infoMsg += " in database '%s'" % unsafeSQLIdentificatorNaming(conf.db)


### PR DESCRIPTION
Change the dump file name to `tablename-columnname-index.csv`
This method can differentiate between situations where a table exports different columns, whereas adding the sequence number to the file name does not change the file type.