### PR TITLE
migrate optparse to argparse

### DIFF
--- a/doc/translations/README-am-ET.md
+++ b/doc/translations/README-am-ET.md
@@ -1,0 +1,52 @@
+# sqlmap ![](https://i.imgur.com/fe85aVR.png)
+
+[![.github/workflows/tests.yml](https://github.com/sqlmapproject/sqlmap/actions/workflows/tests.yml/badge.svg)](https://github.com/sqlmapproject/sqlmap/actions/workflows/tests.yml) [![Python 2.6|2.7|3.x](https://img.shields.io/badge/python-2.6|2.7|3.x-yellow.svg)](https://www.python.org/) [![License](https://img.shields.io/badge/license-GPLv2-red.svg)](https://raw.githubusercontent.com/sqlmapproject/sqlmap/master/LICENSE) [![Twitter](https://img.shields.io/badge/twitter-@sqlmap-blue.svg)](https://twitter.com/sqlmap)
+
+sqlmap የ SQL ማስገብያ ጉድለቶችን ፈልጎ የሚያገኝ እና የውሂብ ጎታ አገልጋዮችን የሚቆጣጠር በራስ ስር የሚሰራ የክፍት ምንጭ ሰርጎ መፈተሻ መሳሪያ ነው። ከኃይለኛ የፍተሻ ሞተር፣ ለመጨረሻው የመግቢያ ሞካሪ ብዙ ልዩ ባህሪያት እና የውሂብ ጎታ አሻራ ማተምን፣ ከመረጃ ቋት ከመጠን በላይ መረጃ ማምጣት፣ የስር የፋይል ስርዓቱን መድረስ እና በስርዓተ ክወናው ላይ ትዕዛዞችን መፈጸምን ጨምሮ ሰፋ ያለ ማብሪያ / ማጥፊያ አለው። -የባንድ ግንኙነቶች.
+
+ቅጽበታዊ ገጽ እይታዎች
+----
+
+![Screenshot](https://raw.github.com/wiki/sqlmapproject/sqlmap/images/sqlmap_screenshot.png)
+
+ይሄን መጎብኘት ይችላሉ። [collection of screenshots](https://github.com/sqlmapproject/sqlmap/wiki/Screenshots) በዊኪ ላይ አንዳንድ አዳዲስ የተጨመሩ ይዘቶችን ይሞክሩ።
+
+አጫጫን
+----
+
+አዲሱን ታርቦል ይሄን በመጫን ማውረድ ይችላሉ [እዚጋ](https://github.com/sqlmapproject/sqlmap/tarball/master) ወይም የቅርብ ጊዜ zipball [እዚጋ](https://github.com/sqlmapproject/sqlmap/zipball/master).
+
+የሚመረጥ ፣ cloning በማድረግ sqlmap ን ማውረድ ይችላሉ። [Git](https://github.com/sqlmapproject/sqlmap) repository:
+
+    git clone --depth 1 https://github.com/sqlmapproject/sqlmap.git sqlmap-dev
+
+sqlmap ከሳጥን ውጭ(ከታሰበለት ውጪ) ይሰራል በ [Python](https://www.python.org/download/) version **2.6**, **2.7** and **3.x** በየትኛውም መድረክ.
+
+አተቃቀም
+----
+
+የመሠረታዊ አማራጮችን እና መቀየሪያዎችን ዝርዝር ለማግኘት የሚከተሉትን ይጠቀሙ፡-
+
+    python sqlmap.py -h
+
+የሁሉንም አማራጮች እና መቀየሪያዎች ዝርዝር ለማግኘት፣ ይጠቀሙ፡-
+
+    python sqlmap.py -hh
+
+የናሙና ፈተና ኢዚጋ ማግኘት ይችላሉ። [ኢዚ](https://asciinema.org/a/46601).
+
+ስለ sqlmap ችሎታዎች አጠቃላይ እይታ ፣ የሚደገፉ ባህሪዎች ዝርዝር እና የሁሉም አማራጮች እና ማብራሪያ / መቀየሪያዎችን ፣ ከምሳሌዎች ጋር እንዲገናኙ ይመከራሉ ።
+[የተጠቃሚ መመሪያ](https://github.com/sqlmapproject/sqlmap/wiki/Usage).
+
+ድረ ገጽ አገናኞች
+----
+
+* Homepage: https://sqlmap.org
+* Download: [.tar.gz](https://github.com/sqlmapproject/sqlmap/tarball/master) or [.zip](https://github.com/sqlmapproject/sqlmap/zipball/master)
+* Commits RSS feed: https://github.com/sqlmapproject/sqlmap/commits/master.atom
+* Issue tracker: https://github.com/sqlmapproject/sqlmap/issues
+* User's manual: https://github.com/sqlmapproject/sqlmap/wiki
+* Frequently Asked Questions (FAQ): https://github.com/sqlmapproject/sqlmap/wiki/FAQ
+* Twitter: [@sqlmap](https://twitter.com/sqlmap)
+* Demos: [https://www.youtube.com/user/inquisb/videos](https://www.youtube.com/user/inquisb/videos)
+* Screenshots: https://github.com/sqlmapproject/sqlmap/wiki/Screenshots

--- a/sqlmapapi.py
+++ b/sqlmapapi.py
@@ -12,7 +12,7 @@ sys.dont_write_bytecode = True
 __import__("lib.utils.versioncheck")  # this has to be the first non-standard import
 
 import logging
-import optparse
+import argparse
 import os
 import warnings
 
@@ -52,14 +52,14 @@ def main():
     setPaths(modulePath())
 
     # Parse command line options
-    apiparser = optparse.OptionParser()
-    apiparser.add_option("-s", "--server", help="Run as a REST-JSON API server", action="store_true")
-    apiparser.add_option("-c", "--client", help="Run as a REST-JSON API client", action="store_true")
-    apiparser.add_option("-H", "--host", help="Host of the REST-JSON API server (default \"%s\")" % RESTAPI_DEFAULT_ADDRESS, default=RESTAPI_DEFAULT_ADDRESS, action="store")
-    apiparser.add_option("-p", "--port", help="Port of the the REST-JSON API server (default %d)" % RESTAPI_DEFAULT_PORT, default=RESTAPI_DEFAULT_PORT, type="int", action="store")
-    apiparser.add_option("--adapter", help="Server (bottle) adapter to use (default \"%s\")" % RESTAPI_DEFAULT_ADAPTER, default=RESTAPI_DEFAULT_ADAPTER, action="store")
-    apiparser.add_option("--username", help="Basic authentication username (optional)", action="store")
-    apiparser.add_option("--password", help="Basic authentication password (optional)", action="store")
+    apiparser = argparse.ArgumentParser(description="SQLMap REST-JSON API Server/Client")
+    apiparser.add_argument("-s", "--server", help="Run as a REST-JSON API server", action="store_true")
+    apiparser.add_argument("-c", "--client", help="Run as a REST-JSON API client", action="store_true")
+    apiparser.add_argument("-H", "--host", help="Host of the REST-JSON API server (default \"%s\")" % RESTAPI_DEFAULT_ADDRESS, default=RESTAPI_DEFAULT_ADDRESS, action="store")
+    apiparser.add_argument("-p", "--port", help="Port of the the REST-JSON API server (default %d)" % RESTAPI_DEFAULT_PORT, default=RESTAPI_DEFAULT_PORT, type="int", action="store")
+    apiparser.add_argument("--adapter", help="Server (bottle) adapter to use (default \"%s\")" % RESTAPI_DEFAULT_ADAPTER, default=RESTAPI_DEFAULT_ADAPTER, action="store")
+    apiparser.add_argument("--username", help="Basic authentication username (optional)", action="store")
+    apiparser.add_argument("--password", help="Basic authentication password (optional)", action="store")
     (args, _) = apiparser.parse_args()
 
     # Start the client or the server


### PR DESCRIPTION
* I've made the improvement in the script by transitioning from `optparse` to `argparse` for command-line option parsing. This change aligns the codebase with recent Python standards, as `argparse` is the recommended module for parsing command-line arguments in current Python versions. This update ensures the script remains compatible and future-proof.