### PR TITLE
Improved Multipart Form handling

### DIFF
--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -226,7 +226,7 @@ def _setRequestParams():
                 if not (kb.processUserMarks and kb.customInjectionMark in conf.data):
                     conf.data = getattr(conf.data, UNENCODED_ORIGINAL_VALUE, conf.data)
                     conf.data = conf.data.replace(kb.customInjectionMark, ASTERISK_MARKER)
-                    conf.data = re.sub(r"(?si)((Content-Disposition[^\n]+?name\s*=\s*[\"']?(?P<name>[^\"'\r\n]+)[\"']?).+?)((%s)+--)" % ("\r\n" if "\r\n" in conf.data else '\n'), functools.partial(process, repl=r"\g<1>%s\g<4>" % kb.customInjectionMark), conf.data)
+                    conf.data = re.sub(r"(?si)((Content-Disposition[^\n]+?name\s*=\s*[\"']?(?P<name>[^\"'\r\n]+)[\"']?).+?)((%s)--)" % ("\r\n" if "\r\n" in conf.data else '\n'), functools.partial(process, repl=r"\g<1>%s\g<4>" % kb.customInjectionMark), conf.data)
 
         if not kb.postHint:
             if kb.customInjectionMark in conf.data:  # later processed

--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -226,7 +226,7 @@ def _setRequestParams():
                 if not (kb.processUserMarks and kb.customInjectionMark in conf.data):
                     conf.data = getattr(conf.data, UNENCODED_ORIGINAL_VALUE, conf.data)
                     conf.data = conf.data.replace(kb.customInjectionMark, ASTERISK_MARKER)
-                    conf.data = re.sub(r"(?si)((Content-Disposition[^\n]+?name\s*=\s*[\"']?(?P<name>[^\"'\r\n]+)[\"']?).+?)((%s)--)" % ("\r\n" if "\r\n" in conf.data else '\n'), functools.partial(process, repl=r"\g<1>%s\g<4>" % kb.customInjectionMark), conf.data)
+                    conf.data = re.sub(r"(?si)((Content-Disposition[^\n]+?name\s*=\s*[\"']?(?P<name>[^\"'\r\n]+)[\"']?).+?)((%s)--)" % ("\r\n" if "\r\n" in conf.data else '\n'), lambda match: match.group(1) + (kb.customInjectionMark if 'filename' not in match.group(0) else '') + match.group(4), conf.data)
 
         if not kb.postHint:
             if kb.customInjectionMark in conf.data:  # later processed

--- a/thirdparty/multipart/multipartpost.py
+++ b/thirdparty/multipart/multipartpost.py
@@ -74,6 +74,10 @@ class MultipartPostHandler(_urllib.request.BaseHandler):
                 part = match.group(0)
                 if b'\r' not in part:
                     request.data = request.data.replace(part, part.replace(b'\n', b"\r\n"))
+            for match in re.finditer(b"(Content-Type[^\\n]+[\\n|\\r|\\r\\n]+)",request.data):
+                part = match.group(0)
+                if b'\r' not in part:
+                    request.data = request.data.replace(part, part.replace(b'\n', b"\r\n"))
 
         return request
 


### PR DESCRIPTION
# Fixes and Improvements in multipart form handling
## 1. improved multipart marker
before
```http
-----------------------------106520758920784323291953035226
Content-Disposition: form-data; name="name"
*

-----------------------------106520758920784323291953035226
Content-Disposition: form-data; name="email"

admin@example.com*
-----------------------------106520758920784323291953035226--
```
marking at wrong location

after fix
```http
-----------------------------106520758920784323291953035226
Content-Disposition: form-data; name="name"

*
-----------------------------106520758920784323291953035226
Content-Disposition: form-data; name="email"

admin@example.com*
-----------------------------106520758920784323291953035226--
```
refering to [rfc 2046](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1:~:text=the%20boundary%20parameter%20value%20from%20the%20Content%2DType%20header%0A%20%20%20field%2C%20optional%20linear%20whitespace%2C%20and%20a%20terminating%20CRLF) multipart forms must have one CRLF between field header and field body.  but here multipart filed processor is marking at wrong location in `name` field.


fix: in lib/core/target.py line 229
`(?si)((Content-Disposition[^\n]+?name\s*=\s*[\"']?(?P<name>[^\"'\r\n]+)[\"']?).+?)((%s)+--)`
`(?si)((Content-Disposition[^\n]+?name\s*=\s*[\"']?(?P<name>[^\"'\r\n]+)[\"']?).+?)((%s)--)`

this regex group `((%s)+--)` is trying to match as many CRLFs as possible but according to rfc need to match one CRLF before `--` removing `+` will only match one CRLF  


## 2. Fixed file corruption.
before
```http
-----------------------------106520758920784323291953035226
Content-Disposition: form-data; name="name"

rohit*
-----------------------------106520758920784323291953035226
Content-Disposition: form-data; name="testfile"; filename="test.pdf"
Content-Type: application/pdf

filecontents*
-----------------------------106520758920784323291953035226--
```
after change
```http
-----------------------------106520758920784323291953035226
Content-Disposition: form-data; name="name"

rohit*
-----------------------------106520758920784323291953035226
Content-Disposition: form-data; name="testfile"; filename="test.pdf"
Content-Type: application/pdf

filecontents
-----------------------------106520758920784323291953035226--
```
marking file fields is leading to file corruption. 
added a if condition to check if the field is file or not.

## 3. Improved dumb LF to CRLF converter in case of Multipart file headers.
before:
```bytes
b'-----------------------------106520758920784323291953035226\r\nContent-Disposition: form-data; name="file"; filename="test.pdf"\r\nContent-Type: application/pdf\n\nfilecontents\r\n-----------------------------106520758920784323291953035226--'
```
it's not properly converting LF to CRLF in case there is any extra header. to fix this added `Content-Type` header which is most common.
```bytes
b'-----------------------------106520758920784323291953035226\r\nContent-Disposition: form-data; name="testfile"; filename="test.pdf"\r\nContent-Type: application/pdf\r\n\r\nidk filename\r\n-----------------------------106520758920784323291953035226--'
```