### PR TITLE
fixed multipart form handling issue (#5602)

### DIFF
--- a/lib/core/target.py
+++ b/lib/core/target.py
@@ -226,7 +226,8 @@ def _setRequestParams():
                 if not (kb.processUserMarks and kb.customInjectionMark in conf.data):
                     conf.data = getattr(conf.data, UNENCODED_ORIGINAL_VALUE, conf.data)
                     conf.data = conf.data.replace(kb.customInjectionMark, ASTERISK_MARKER)
-                    conf.data = re.sub(r"(?si)((Content-Disposition[^\n]+?name\s*=\s*[\"']?(?P<name>[^\"'\r\n]+)[\"']?).+?)((%s)--)" % ("\r\n" if "\r\n" in conf.data else '\n'), functools.partial(process, repl=r"\g<1>%s\g<4>" % kb.customInjectionMark), conf.data)
+                    conf.data = re.sub(r"(?si)(Content-Disposition:[^\n]+\s+name=\"(?P<name>[^\"]+)\"(?:[^f|^b]|f(?!ilename=)|b(?!oundary=))*?)((%s)--)" % ("\r\n" if "\r\n" in conf.data else '\n'),
+                                        functools.partial(process, repl=r"\g<1>%s\g<3>" % kb.customInjectionMark), conf.data)
 
         if not kb.postHint:
             if kb.customInjectionMark in conf.data:  # later processed


### PR DESCRIPTION
Fixed issue #5602 

modified the regex to find if there are any file field and multipart/mixed specific attributes like `filename` and `boundary`
based on [spec](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2)

new regex:
```regex
(?si)(Content-Disposition:[^\n]+\s+name=\"(?P<name>[^\"]+)\"(?:[^f|^b]|f(?!ilename=)|b(?!oundary=))*?)((%s)--)
```

indented code following [PEP8](https://peps.python.org/pep-0008/#indentation) to make it more readable