### PR TITLE
Update Deprecated `readfp()` Usage

### DIFF
--- a/lib/parse/configfile.py
+++ b/lib/parse/configfile.py
@@ -68,7 +68,7 @@ def configFileParser(configFile):
 
     try:
         config = UnicodeRawConfigParser()
-        config.readfp(configFP)
+        config.read_file(configFP)
     except Exception as ex:
         errMsg = "you have provided an invalid and/or unreadable configuration file ('%s')" % getSafeExString(ex)
         raise SqlmapSyntaxException(errMsg)


### PR DESCRIPTION
"you have provided an invalid and/or unreadable configuration file ('AttributeError: 'UnicodeRawConfigParser' object has no attribute 'readfp'')"

Replaced deprecated `readfp()` method with `read_file()` method for Python 3 compatibility in one instance.

Change Made:
Updated `readfp()` to `read_file()` in `UnicodeRawConfigParser` initialization.