### PR TITLE
Fixed an issue with using -r to parse requests for host:ip unspliced ​​ports

### DIFF
--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -5401,8 +5401,6 @@ def parseRequestFile(reqFile, checkParams=True):
                             scheme, value = value.split('://')[:2]
 
                         port = extractRegexResult(r":(?P<result>\d+)\Z", value)
-                        if port:
-                            value = value[:-(1 + len(port))]
 
                         host = value
 


### PR DESCRIPTION
When the host in the file has a port, parseRequestFile will not splice the port to the host.