### PR TITLE
Update option.py

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -1360,7 +1360,7 @@ def _setHTTPAuthentication():
             errMsg += "be in format 'DOMAIN\\username:password'"
         elif authType == AUTH_TYPE.PKI:
             errMsg = "HTTP PKI authentication require "
-            errMsg += "usage of option `--auth-pki`"
+            errMsg += "usage of option `--auth-file`"
             raise SqlmapSyntaxException(errMsg)
 
         aCredRegExp = re.search(regExp, conf.authCred)


### PR DESCRIPTION
auth-type=pki requires auth-file option to pass in a certificate. auth-pki is not a valid option