### PR TITLE
Use API to check Tor connection

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -11,6 +11,7 @@ import codecs
 import functools
 import glob
 import inspect
+import json
 import logging
 import os
 import random
@@ -2544,11 +2545,12 @@ def _checkTor():
     logger.info(infoMsg)
 
     try:
-        page, _, _ = Request.getPage(url="https://check.torproject.org/", raise404=False)
+        page, _, _ = Request.getPage(url="https://check.torproject.org/api/ip", raise404=False)
+        content = json.loads(page)
     except SqlmapConnectionException:
-        page = None
+        content = None
 
-    if not page or "Congratulations" not in page:
+    if not content or not content.get("IsTor"):
         errMsg = "it appears that Tor is not properly set. Please try using options '--tor-type' and/or '--tor-port'"
         raise SqlmapConnectionException(errMsg)
     else:


### PR DESCRIPTION
This PR changes the way the sqlmap checks the Tor connection.
Currently, https://check.torproject.org/ is fetched and checked, whether it contains `Congratulations`.
With this PR, https://check.torproject.org/api/ip is used instead, because I think using a JSON API is much cleaner, more reliable / stable and consumes less data.

The `--check-tor` has been first implemented in https://github.com/sqlmapproject/sqlmap/commit/86b4a3562f1949398ea99dc59aaf3ae20ce0a793, before the JSON API (https://gitlab.torproject.org/tpo/network-health/metrics/tor-check/-/commit/727327d4f1f3ecd5209f5ea2e827676019c56459) has been added to check.torproject.org.