### PR TITLE
fix parsing single header via --headers parameter

### DIFF
--- a/lib/core/option.py
+++ b/lib/core/option.py
@@ -1410,6 +1410,8 @@ def _setHTTPExtraHeaders():
             conf.headers = conf.headers.replace("\r\n", "\n").split("\n")
         elif "\\n" in conf.headers:
             conf.headers = conf.headers.replace("\\r\\n", "\\n").split("\\n")
+        else:
+            headers = [headers]
 
         for headerValue in conf.headers:
             if not headerValue.strip():


### PR DESCRIPTION
Fix of #5908 introduced new error.
Sqlmapapi scan can not start if --headers contains only one header

Example: 
`python3 sqlmap.py --url="https://example.com" --method="POST" --headers="Age: 99*" `

It returns error 
`[15:30:25] [CRITICAL] invalid header value: 'A'. Valid header format is 'name:value'`

Before patching #5908 `conf.headers` was always of array type, because of [.split()](https://github.com/sqlmapproject/sqlmap/blob/c2f0ca314c133b38532e9c1037b36c966075ed6a/lib/core/option.py#L1408)
After patching .split is not called on single value and [`for headerValue in conf.headers:` ](https://github.com/sqlmapproject/sqlmap/blob/e60bd21b08d6d9420886c678803ab62cbe8fc5d3/lib/core/option.py#L1413)started working with a string value and itrating characters