### PR TITLE
Create equal2nullsafequals.py

### DIFF
--- a/tamper/equal2nullsafequals.py
+++ b/tamper/equal2nullsafequals.py
@@ -22,8 +22,6 @@ def tamper(payload, **kwargs):
     >>> tamper("OR 1=1 #")
     'OR 1<=>1 #'
     """
-    if not payload:
-        return payload
-    # Replace '=' with '<=>'
-    payload = re.sub(r'(?<![><!])=(?!=)', '<=>', payload)
-    return payload
+    if payload:
+        # Replace '=' with '<=>'
+        return re.sub(r'(?<![><!])=(?!=)', '<=>', payload)


### PR DESCRIPTION
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="UTF-8" />
</head>
<body>

<h2 style="text-align:center;">DBMS Support for MySQL NULL-safe Equality Operator &lt;=&gt;</h2>

<table>
  <thead>
    <tr>
      <th>DBMS</th>
      <th>Supports &lt;=&gt; Operator?</th>
      <th>Notes</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>MySQL</td>
      <td>Yes</td>
      <td>Native NULL-safe equality operator</td>
    </tr>
    <tr>
      <td>MariaDB</td>
      <td>Yes</td>
      <td>Compatible with MySQL syntax</td>
    </tr>
    <tr>
      <td>PostgreSQL</td>
      <td>No</td>
      <td>Does not support &lt;=&gt;; use IS NOT DISTINCT FROM for NULL-safe equality</td>
    </tr>
    <tr>
      <td>SQLite</td>
      <td>No</td>
      <td>No equivalent operator; use IS NULL or IS NOT NULL for NULL checks</td>
    </tr>
    <tr>
      <td>Microsoft SQL Server</td>
      <td>No</td>
      <td>No &lt;=&gt;; use ISNULL() or CASE expressions for NULL-safe comparison</td>
    </tr>
    <tr>
      <td>Oracle</td>
      <td>No</td>
      <td>No &lt;=&gt;; use NVL or CASE expressions for NULL-safe comparison</td>
    </tr>
  </tbody>
</table>

</body>
</html>

# Use Cases
<h5>Sometime weak waf/Filters filter <strong>(=)</strong> Using <strong>(<=>)</strong> instead bypass WAF/Filters filter equal sign</h5>