### PR TITLE
Fix mysql fingerprint confirmation

### DIFF
--- a/plugins/dbms/mysql/fingerprint.py
+++ b/plugins/dbms/mysql/fingerprint.py
@@ -192,7 +192,8 @@ class Fingerprint(GenericFingerprint):
             infoMsg = "confirming %s" % DBMS.MYSQL
             logger.info(infoMsg)
 
-            result = inject.checkBooleanExpression("SESSION_USER() LIKE USER()")
+            # user@% LIKE user@host OR user@host LIKE user@%
+            result = inject.checkBooleanExpression("SESSION_USER() LIKE USER() OR USER() LIKE SESSION_USER()")
 
             if not result:
                 # Note: MemSQL doesn't support SESSION_USER()


### PR DESCRIPTION
Hey,
I could not make sqlmap fingerprint a server, which was definitely mysql/mariadb, despite the use of `--dbms mysql` (or `mariadb`).
`SESSION_USER()` returned `user@host` while `USER()` returned `user@%`, which yielded `0` (not confirmed).
I added a check for the same condition but the other way around, so both cases confirm mysql/mariadb as the dbms.