### PR TITLE
fix logic bug in thread init

### DIFF
--- a/sqlmap.py
+++ b/sqlmap.py
@@ -601,7 +601,7 @@ def main():
 
         # short delay for thread finalization
         _ = time.time()
-        while threading.active_count() > 1 and (time.time() - _) > THREAD_FINALIZATION_TIMEOUT:
+        while threading.active_count() > 1 and (time.time() - _) < THREAD_FINALIZATION_TIMEOUT:
             time.sleep(0.01)
 
         if cmdLineOptions.get("sqlmapShell"):


### PR DESCRIPTION
the thread finalization loop used a reversed comparison, causing the wait loop to be skipped immediately:

this change reverse the comparison so it will wait while there are active threads and elapsed time is less than the configured THREAD_FINALIZATION_TIMEOUT: