### PR TITLE
Fix bug in 302 redirect

### DIFF
--- a/lib/request/redirecthandler.py
+++ b/lib/request/redirecthandler.py
@@ -76,7 +76,10 @@ class SmartRedirectHandler(_urllib.request.HTTPRedirectHandler):
         redurl = self._get_header_redirect(headers) if not conf.ignoreRedirects else None
 
         try:
-            content = fp.read(MAX_CONNECTION_TOTAL_SIZE)
+            content = fp.fp.read(MAX_CONNECTION_TOTAL_SIZE)
+            buffered_copy = io.BytesIO(content)
+            buffered_copy.seek(0)
+            fp.fp = buffered_copy
         except:  # e.g. IncompleteRead
             content = b""
         finally:


### PR DESCRIPTION
I recently came an assessment where an SQL injection was exploitable on a page that kept triggering a 302 return code. I used the `--ignore-redirects` switch. However, for no obvious reasons at first, sqlmap failed to exploit the injection.
Upon some quick investigation, here is the piece of code responsible for that behavior:

https://github.com/sqlmapproject/sqlmap/blob/master/lib/request/redirecthandler.py#L79
```python
    def http_error_302(self, req, fp, code, msg, headers):
        start = time.time()
        content = None
        forceRedirect = False
        redurl = self._get_header_redirect(headers) if not conf.ignoreRedirects else None

        try:
            content = fp.read(MAX_CONNECTION_TOTAL_SIZE)
        except:  # e.g. IncompleteRead
            content = b""
        finally:
            if content:
                try:  # try to write it back to the read buffer so we could reuse it in further steps
                    fp.fp._rbuf.truncate(0)
                    fp.fp._rbuf.write(content)
                except:
                    pass
```

The `fp.read` just read the content of the `fp.fp` objects which is of type `HTTPResponse(io.BufferedIOBase)`. However, in my context, this object is not truncable, seekable and is read only. Once read, it not readable again.
I guess thats why the `finally` block is important, it tries to reset the buffer for application code to parse its content again for sqlmap logic. However, in my case, the `fp.fp` objects is set to `None` after the `fp.read([...])` call. Moreover, even before it is being read, the ioBuffer does not allow truncating or similar operations that would result in the behavior of the try switch.
Since the `truncate + write` code is from 13 years ago, I guess the under the hood objects of python have changed.
The following pull request aims to solve that issue.

For context, the bug was encountered using both pypi package and the latest commit of sqlmap (6d4123c27dbe3ec2f595dfb06494e0b82d87f70f) on a debian 13 Trixie up-to-date:

```
$ python3 --version
Python 3.13.5
```
