### PR TITLE
fix(httpshandler): close socket when SSL handshake fails with exception

### DIFF
--- a/lib/request/httpshandler.py
+++ b/lib/request/httpshandler.py
@@ -94,6 +94,7 @@ class HTTPSConnection(_http_client.HTTPSConnection):
                         sock.close()
                 except (ssl.SSLError, socket.error, _http_client.BadStatusLine, AttributeError) as ex:
                     self._tunnel_host = None
+                    sock.close()
                     logger.debug("SSL connection error occurred for '%s' ('%s')" % (_lut[protocol], getSafeExString(ex)))
 
         elif hasattr(ssl, "wrap_socket"):
@@ -111,6 +112,7 @@ class HTTPSConnection(_http_client.HTTPSConnection):
                         sock.close()
                 except (ssl.SSLError, socket.error, _http_client.BadStatusLine) as ex:
                     self._tunnel_host = None
+                    sock.close()
                     logger.debug("SSL connection error occurred for '%s' ('%s')" % (_lut[protocol], getSafeExString(ex)))
 
         if not success:


### PR DESCRIPTION
I noticed that when sqlmap tries different SSL/TLS versions to connect to a server, it wasn't closing the socket if the handshake threw an exception. Each failed attempt left an open socket behind, which could add up to a resource leak over time.

The fix:
Pretty straightforward - I added sock.close() to both exception handlers in HTTPSConnection.connect(). This matches what the code already does when wrap_socket returns a falsy value (see lines 94 and 112), so it's just making the error path consistent with the existing cleanup logic.

Why it matters:
When scanning a lot of targets, or when a server rejects certain TLS versions, these leaked sockets could pile up and eventually hit system limits ("too many open files"). Not catastrophic, but definitely something worth fixing.

Tested by:
Verified the module imports cleanly
Checked that the fix follows the same pattern already used elsewhere in the function
