### PR TITLE
Fix broken GitHub downloads URL in update message

### DIFF
--- a/lib/core/update.py
+++ b/lib/core/update.py
@@ -163,7 +163,7 @@ def update():
             infoMsg += "to use a GitHub for Windows client for updating "
             infoMsg += "purposes (https://desktop.github.com/) or just "
             infoMsg += "download the latest snapshot from "
-            infoMsg += "https://github.com/sqlmapproject/sqlmap/downloads"
+            infoMsg += "https://github.com/sqlmapproject/sqlmap/releases"
         else:
             infoMsg = "for Linux platform it's recommended "
             infoMsg += "to install a standard 'git' package (e.g.: 'apt install git')"


### PR DESCRIPTION
Hey there! 

I noticed that when sqlmap fails to update on Windows, it shows users a link to download the latest version from github.com/sqlmapproject/sqlmap/downloads - but that page doesn't exist anymore (returns 404).

GitHub removed the Downloads feature a while back in favor of Releases. This small change just updates the URL to point to /releases instead, which actually works and has the download links users need.

**Before:** Broken link  404 page
**After:** Working link  Releases page with download options

Nothing fancy, just a quick fix to help Windows users who run into update issues.