### PR TITLE
Make XML/HTML encoding in SOAP requests optional

### DIFF
--- a/lib/core/optiondict.py
+++ b/lib/core/optiondict.py
@@ -63,6 +63,7 @@ optDict = {
         "safeReqFile": "string",
         "safeFreq": "integer",
         "skipUrlEncode": "boolean",
+        "skipXmlEncode": "boolean",
         "csrfToken": "string",
         "csrfUrl": "string",
         "csrfMethod": "string",

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -276,6 +276,9 @@ def cmdLineParser(argv=None):
         request.add_argument("--skip-urlencode", dest="skipUrlEncode", action="store_true",
             help="Skip URL encoding of payload data")
 
+        request.add_argument("--skip-xml-encode", dest="skipXmlEncode", action="store_true",
+            help="Skip HTML encoding of payload data for SOAP/XML")
+
         request.add_argument("--csrf-token", dest="csrfToken",
             help="Parameter used to hold anti-CSRF token")
 

--- a/lib/request/connect.py
+++ b/lib/request/connect.py
@@ -1116,7 +1116,7 @@ class Connect(object):
             logger.log(CUSTOM_LOGGING.PAYLOAD, safecharencode(payload.replace('\\', BOUNDARY_BACKSLASH_MARKER)).replace(BOUNDARY_BACKSLASH_MARKER, '\\'))
 
             if place == PLACE.CUSTOM_POST and kb.postHint:
-                if kb.postHint in (POST_HINT.SOAP, POST_HINT.XML):
+                if kb.postHint in (POST_HINT.SOAP, POST_HINT.XML) and not conf.skipXmlEncode:
                     # payloads in SOAP/XML should have chars > and < replaced
                     # with their HTML encoded counterparts
                     payload = payload.replace("&#", SAFE_HEX_MARKER)

--- a/sqlmap.conf
+++ b/sqlmap.conf
@@ -198,6 +198,10 @@ safeFreq = 0
 # Valid: True or False
 skipUrlEncode = False
 
+# Skip HTML encoding of payload data for SOAP/XML.
+# Valid: True or False
+skipXmlEncode = False
+
 # Parameter used to hold anti-CSRF token.
 csrfToken = 
 


### PR DESCRIPTION
sqlmap by default XML/HTML-encodes payloads when the HTTP request contains an XML structure (e.g., in SOAP requests).

However, this behavior may not be desired, for example, when injecting into a character data (CDATA) section like so:

`<soapmsg>
<input><![CDATA[INJECTIONHERE]]></input>
</soapmsg>`

Currently, the XML/HTML-encoding cannot be disabled in sqlmap and has to be achieved with external means, for example via intercepting the emitted HTTP requests and performing match/replace actions.

Therefore, the suggestion of this pull request is to make the XML/HTML-encoding optional and let the user disable it with:

--skip-xml-encode (similar to --skip-url-encode)