### PR TITLE
Fix stdoutEncode mangling non-string values used by REST API (#6054)

### DIFF
--- a/lib/core/convert.py
+++ b/lib/core/convert.py
@@ -412,6 +412,8 @@ def stdoutEncode(value):
     Returns textual representation of a given value safe for writing to stdout
     >>> stdoutEncode(b"foobar")
     'foobar'
+    >>> stdoutEncode({"url": "http://example.com/foo", "data": "id=1"}) == {"url": "http://example.com/foo", "data": "id=1"}
+    True
     """
 
     if value is None:
@@ -437,7 +439,11 @@ def stdoutEncode(value):
         if isinstance(value, (bytes, bytearray)):
             value = getUnicode(value, encoding)
         elif not isinstance(value, str):
-            value = str(value)
+            # Non-string values (e.g. dicts passed through the REST API path,
+            # where the overridden sys.stdout.write JSON-encodes the value)
+            # must be returned unchanged — stringifying them via str() yields
+            # Python repr() output that the API consumer cannot parse.
+            return value
 
         try:
             retVal = value.encode(encoding, errors="replace").decode(encoding, errors="replace")


### PR DESCRIPTION
Closes #6054.

## What broke

In commit 09fadc43d3 ("Minor improvement of stdoutEncode", 2025-12-31), the non-string branch of `stdoutEncode` changed from passing values through unchanged to coercing them with `str()`:

```python
elif not isinstance(value, str):
    value = str(value)
```

This breaks the REST API path. `lib/utils/api.py` overrides `sys.stdout.write` to call `jsonize(value)`, which expects the original Python value (e.g. a `dict`). The existing call chain in `lib/controller/controller.py:181` is:

```python
conf.dumper.string("", {"url": conf.url, "query": ..., "data": ...},
                   content_type=CONTENT_TYPE.TARGET)
```

flowing through `Dumper.string()` → `_write()` → `dataToStdout()` → `sys.stdout.write(stdoutEncode(...))`.

After the regression, the API now returns Python `repr()` strings instead of structured JSON for `value` fields:

```diff
- "value": {"url": "http://example.com/foo", "data": "id=1"}
+ "value": "{'url': 'http://example.com/foo', 'data': 'id=1'}"
```

Any client parsing the documented response shape breaks.

## The fix

Restore the pre-1.10 behavior of returning non-string, non-bytes values unchanged. This matches the `else: retVal = value` branch the previous implementation had.

The encode/decode round-trip below is meaningful only for strings and bytes — applying it to dicts/lists/etc. has never been correct.

## Verification

```python
>>> stdoutEncode(b'foobar')          # unchanged
'foobar'
>>> stdoutEncode('hello')            # unchanged
'hello'
>>> stdoutEncode({'url': '...'})     # was repr'd; now passes through
{'url': '...'}
>>> stdoutEncode([1, 2, 3])          # passes through
[1, 2, 3]
```

Added a doctest covering the dict case so this can't silently regress again.

`python3 -m doctest lib/core/convert.py` — all 38 tests pass.