### PR TITLE
fix(common): use lazy quantifiers in removeDynamicContent to avoid over-matching

### DIFF
--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -3298,6 +3298,11 @@ def removeDynamicContent(page):
     """
     Removing dynamic content from supplied page basing removal on
     precalculated dynamic markings
+
+    Note: lazy quantifiers (`.+?`) are used on purpose. Greedy matching
+    would collapse everything between the first prefix and the last
+    suffix on pages where those anchors repeat (e.g. SPAs, templated
+    listings), masking real differences between True/False responses.
     """
 
     if page:
@@ -3307,11 +3312,11 @@ def removeDynamicContent(page):
             if prefix is None and suffix is None:
                 continue
             elif prefix is None:
-                page = re.sub(r"(?s)^.+%s" % re.escape(suffix), suffix.replace('\\', r'\\'), page)
+                page = re.sub(r"(?s)^.+?%s" % re.escape(suffix), suffix.replace('\\', r'\\'), page)
             elif suffix is None:
                 page = re.sub(r"(?s)%s.+$" % re.escape(prefix), prefix.replace('\\', r'\\'), page)
             else:
-                page = re.sub(r"(?s)%s.+%s" % (re.escape(prefix), re.escape(suffix)), "%s%s" % (prefix.replace('\\', r'\\'), suffix.replace('\\', r'\\')), page)
+                page = re.sub(r"(?s)%s.+?%s" % (re.escape(prefix), re.escape(suffix)), "%s%s" % (prefix.replace('\\', r'\\'), suffix.replace('\\', r'\\')), page)
 
     return page
 


### PR DESCRIPTION
## What changed

`removeDynamicContent()` was using greedy `.+` between dynamic-marking anchors.  
On any page where the same prefix/suffix shows up more than once (SPAs, templated lists, repeated card components), that single greedy match would swallow everything from the first prefix to the last suffix and replace it with one collapsed block.

That over-cleanup hides real differences between True/False responses and feeds straight into false positives (and false negatives) downstream in the comparison logic.

I switched the two affected patterns from greedy to lazy:

- `^.+suffix` → `^.+?suffix` for the "suffix-only" case, so we stop at the first suffix instead of the last
- `prefix.+suffix` → `prefix.+?suffix` for the "both anchors" case, so each dynamic block gets cleaned individually instead of all of them merging into one
- the `prefix.+$` case stayed as-is — it's anchored at end-of-string, so greedy vs lazy doesn't change the result there
- added a short note in the docstring so nobody accidentally reverts this back to greedy later

## Why this is better

The dynamic markings represent a single dynamic block, not a region spanning the entire page. Greedy was breaking that contract whenever the anchors repeated.

Some specifics worth calling out:

- with lazy matching, `re.sub` (which is global by default) actually walks the page and cleans each dynamic region one by one, which is what the markings were designed for
- this lines up the cleanup logic with how `findDynamicContent` builds the markings in the first place
- pages that don't have repeating anchors behave identically — same single match, same replacement
- combined with the matchRatio calibration fix from the earlier PR, the comparison engine now sees genuine True/False deltas instead of artificially flattened pages

## Scope

Only `lib/core/common.py` is touched.  
Change is limited to `removeDynamicContent()` — two regex quantifiers and a docstring note.  
No public API changes, no behavior change on pages without repeating anchors.