### PR TITLE
Fix Oracle current_db query to return actual database name

### DIFF
--- a/data/xml/queries.xml
+++ b/data/xml/queries.xml
@@ -250,7 +250,8 @@
         NOTE: current physical DB but not usable for enumeration
         <current_db query="SELECT SYS.DATABASE_NAME FROM DUAL"/>
         -->
-        <current_db query="SELECT USER FROM DUAL"/>
+        <!-- ORA_DATABASE_NAME works for any user in Oracle 12c+; fallback to USER for older versions -->
+        <current_db query="SELECT ORA_DATABASE_NAME FROM DUAL" query2="SELECT USER FROM DUAL"/>
         <!--
              NOTE: in Oracle to check if the session user is DBA you can use:
              SELECT USERENV('ISDBA') FROM DUAL


### PR DESCRIPTION
Previously used SELECT USER FROM DUAL which returns the username,
not the database name. Replaced with ORA_DATABASE_NAME which returns
the actual DB name for any user on Oracle 12c+. USER kept as query2
fallback for older Oracle versions.

Tested on Oracle 21c XE via Docker (gvenzl/oracle-xe:21-slim)"

<img width="1067" height="120" alt="image" src="https://github.com/user-attachments/assets/1a519fc0-91e3-4d42-9150-9e6e42075e61" />

