### PR TITLE
Fix RTL rendering of file extensions in Arabic Readme

### DIFF
--- a/doc/translations/README-ar-AR.md
+++ b/doc/translations/README-ar-AR.md
@@ -58,7 +58,7 @@
 ----
 
 * الصفحة الرئيسية: https://sqlmap.org
-* التحميل: [.tar.gz](https://github.com/sqlmapproject/sqlmap/tarball/master) أو [.zip](https://github.com/sqlmapproject/sqlmap/zipball/master)
+* التحميل: [&#x202A;.tar.gz&#x202C;](https://github.com/sqlmapproject/sqlmap/tarball/master) أو [&#x202A;.zip&#x202C;](https://github.com/sqlmapproject/sqlmap/zipball/master)
 * تغذية التحديثات RSS: https://github.com/sqlmapproject/sqlmap/commits/master.atom
 * تتبع المشكلات: https://github.com/sqlmapproject/sqlmap/issues
 * دليل المستخدم: https://github.com/sqlmapproject/sqlmap/wiki


### PR DESCRIPTION
File extensions (.zip, .tar.gz) were displaying as "zip." and "tar.gz."
because Arabic is RTL but file extensions are LTR tokens. Wrapped them
with Unicode LTR embedding markers (U+202A / U+202C) to force correct
left-to-right rendering inside the RTL context.


# Before

<div align="center" >

<img width="542" height="137" alt="image" src="https://github.com/user-attachments/assets/f9ab1042-3f3b-49df-98ca-934a26adebde" />

</div>

# After 

<div align="center" >
<img width="581" height="97" alt="image" src="https://github.com/user-attachments/assets/87256808-bca0-49fe-9b7d-ed2cb3a3122a" />
</div>


