### PR TITLE
feat(errors): add error fingerprints for CockroachDB, YugabyteDB, DuckDB, Trino, OpenGauss, Doris, StarRocks

### DIFF
--- a/data/xml/errors.xml
+++ b/data/xml/errors.xml
@@ -21,9 +21,22 @@
         <error regexp="MemSQL does not support this type of query" fork="MemSQL"/>
         <error regexp="is not supported by MemSQL" fork="MemSQL"/>
         <error regexp="unsupported nested scalar subselect" fork="MemSQL"/>
+        <error regexp="check the manual that (corresponds to|fits) your (Apache )?Doris server version" fork="Doris"/>
+        <error regexp="org\.apache\.doris\." fork="Doris"/>
+        <error regexp="check the manual that (corresponds to|fits) your StarRocks server version" fork="StarRocks"/>
+        <error regexp="com\.starrocks\." fork="StarRocks"/>
     </dbms>
 
     <dbms value="PostgreSQL">
+        <error regexp="CockroachDB.*?ERROR" fork="CockroachDB"/>
+        <error regexp="check the manual that (corresponds to|fits) your CockroachDB server version" fork="CockroachDB"/>
+        <error regexp="pgwire/pgerror" fork="CockroachDB"/>
+        <error regexp="crdb_internal\." fork="CockroachDB"/>
+        <error regexp="YugabyteDB.*?ERROR" fork="YugabyteDB"/>
+        <error regexp="check the manual that (corresponds to|fits) your YugabyteDB server version" fork="YugabyteDB"/>
+        <error regexp="org\.yb\." fork="YugabyteDB"/>
+        <error regexp="openGauss.*?ERROR" fork="OpenGauss"/>
+        <error regexp="org\.opengauss\.util\.PSQLException" fork="OpenGauss"/>
         <error regexp="PostgreSQL.*?ERROR"/>
         <error regexp="Warning.*?\Wpg_"/>
         <error regexp="valid PostgreSQL result"/>
@@ -118,6 +131,10 @@
     </dbms>
 
     <dbms value="SQLite">
+        <error regexp="duckdb\.duckdb\.(Parser|Binder|Catalog|Conversion)Exception" fork="DuckDB"/>
+        <error regexp="org\.duckdb\.DuckDBException" fork="DuckDB"/>
+        <error regexp="Parser Error: syntax error at or near" fork="DuckDB"/>
+        <error regexp="Binder Error: Table with name" fork="DuckDB"/>
         <error regexp="SQLite/JDBCDriver"/>
         <error regexp="SQLite\.Exception"/>
         <error regexp="(Microsoft|System)\.Data\.SQLite\.SQLiteException"/>
@@ -208,6 +225,8 @@
         <error regexp="com\.simba\.presto\.jdbc"/>
         <error regexp="UNION query has different number of fields: \d+, \d+"/>
         <error regexp="line \d+:\d+: mismatched input '[^']+'. Expecting:"/>
+        <error regexp="io\.trino\.jdbc" fork="Trino"/>
+        <error regexp="io\.trino\.spi\." fork="Trino"/>
     </dbms>
 
     <dbms value="Altibase">

--- a/tests/test_html_parser_forks.py
+++ b/tests/test_html_parser_forks.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2006-2026 sqlmap developers (https://sqlmap.org)
+See the file 'LICENSE' for copying permission
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _testutils import bootstrap
+bootstrap()
+
+from lib.core.data import kb
+from lib.core.enums import DBMS
+from lib.core.enums import FORK
+from lib.parse.html import htmlParser
+
+
+class TestHtmlParserForks(unittest.TestCase):
+    def setUp(self):
+        kb.forkNote = None
+        kb.cache.parsedDbms.clear()
+
+    def test_cockroachdb_error_fingerprint(self):
+        page = "ERROR: at or near \"SELECT\": syntax error in CockroachDB pgwire/pgerror"
+        dbms = htmlParser(page)
+        self.assertEqual(dbms, DBMS.PGSQL)
+        self.assertEqual(kb.forkNote, FORK.COCKROACHDB)
+
+    def test_yugabytedb_error_fingerprint(self):
+        page = "YugabyteDB ERROR: check the manual that corresponds to your YugabyteDB server version"
+        dbms = htmlParser(page)
+        self.assertEqual(dbms, DBMS.PGSQL)
+        self.assertEqual(kb.forkNote, FORK.YUGABYTEDB)
+
+    def test_opengauss_error_fingerprint(self):
+        page = "openGauss ERROR: org.opengauss.util.PSQLException: syntax error"
+        dbms = htmlParser(page)
+        self.assertEqual(dbms, DBMS.PGSQL)
+        self.assertEqual(kb.forkNote, FORK.OPENGAUSS)
+
+    def test_duckdb_error_fingerprint(self):
+        page = "org.duckdb.DuckDBException: duckdb.duckdb.ParserException: syntax error"
+        dbms = htmlParser(page)
+        self.assertEqual(dbms, DBMS.SQLITE)
+        self.assertEqual(kb.forkNote, FORK.DUCKDB)
+
+    def test_trino_error_fingerprint(self):
+        page = "io.trino.jdbc.TrinoSQLException: line 1:1: mismatched input 'SELECT'"
+        dbms = htmlParser(page)
+        self.assertEqual(dbms, DBMS.PRESTO)
+        self.assertEqual(kb.forkNote, FORK.TRINO)
+
+    def test_doris_error_fingerprint(self):
+        page = "check the manual that corresponds to your Apache Doris server version with org.apache.doris.qm"
+        dbms = htmlParser(page)
+        self.assertEqual(dbms, DBMS.MYSQL)
+        self.assertEqual(kb.forkNote, FORK.DORIS)
+
+    def test_starrocks_error_fingerprint(self):
+        page = "check the manual that corresponds to your StarRocks server version with com.starrocks.sql"
+        dbms = htmlParser(page)
+        self.assertEqual(dbms, DBMS.MYSQL)
+        self.assertEqual(kb.forkNote, FORK.STARROCKS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR adds missing error message regex patterns to `data/xml/errors.xml` for DBMS forks already declared in `lib/core/enums.py` (`FORK` class):
- **CockroachDB** (PostgreSQL fork): `CockroachDB.*?ERROR`, `pgwire/pgerror`, `crdb_internal\.`, version string check
- **YugabyteDB** (PostgreSQL fork): `YugabyteDB.*?ERROR`, `org\.yb\.`, version string check
- **OpenGauss** (PostgreSQL fork): `openGauss.*?ERROR`, `org\.opengauss\.util\.PSQLException`
- **DuckDB** (SQLite fork): `duckdb\.duckdb\.(Parser|Binder|Catalog|Conversion)Exception`, `org\.duckdb\.DuckDBException`, `Parser Error: syntax error at or near`
- **Trino** (Presto fork): `io\.trino\.jdbc`, `io\.trino\.spi\.`
- **Doris** (MySQL fork): `org\.apache\.doris\.`, version string check
- **StarRocks** (MySQL fork): `com\.starrocks\.`, version string check

## Verification & Testing
- Added unit tests in `tests/test_html_parser_forks.py` verifying all fork detections and `kb.forkNote` population.
- Ran full test suite: `python3 -m unittest discover tests` -> **2631 tests passed** (0 failures).
- Ran smoke test: `python3 sqlmap.py --smoke` -> **PASSED**.